### PR TITLE
Earthrise refactor

### DIFF
--- a/boards/verilator/README.md
+++ b/boards/verilator/README.md
@@ -30,7 +30,7 @@ Each chapter top module uses an instance of the common chapter design from [hard
 
 ### Verilog Debug Messages
 
-Some Isle components (such as Earthrise) output debug messages using `$display(...)`. These messages are enabled or disabled in: `/Users/flux/src/isle/boards/verilator/verilator.mk`
+Some Isle components (such as Earthrise) output debug messages using `$display(...)`. These messages are enabled or disabled in: `boards/verilator/verilator.mk`
 
 Simply comment out `VERILOG_DEBUG` if you don't want debug output.
 

--- a/boards/verilator/README.md
+++ b/boards/verilator/README.md
@@ -28,6 +28,12 @@ Many chapters have parameters you can edit in the matching top module. For examp
 
 Each chapter top module uses an instance of the common chapter design from [hardware/book](../../hardware/book/).
 
+### Verilog Debug Messages
+
+Some Isle components (such as Earthrise) output debug messages using `$display(...)`. These messages are enabled or disabled in: `/Users/flux/src/isle/boards/verilator/verilator.mk`
+
+Simply comment out `VERILOG_DEBUG` if you don't want debug output.
+
 ### Unknown Verilator Lint Message Code
 
 Verilator introduces new lint waivers from time to time; unfortunately, this trips up older versions of Verilator. If Verilator gives an error message of the form "Unknown Verilator lint message code" you have two options:

--- a/boards/verilator/verilator.mk
+++ b/boards/verilator/verilator.mk
@@ -4,6 +4,7 @@
 
 VFLAGS = -O3
 CFLAGS = -std=c++17
+VERILOG_DEBUG = -DDEBUG
 SDL_CFLAGS = `sdl2-config --cflags`
 SDL_LDFLAGS = `sdl2-config --libs`
 OPT_FLAGS = -O3 -march=native -mtune=native -flto
@@ -12,7 +13,7 @@ OPT_FLAGS = -O3 -march=native -mtune=native -flto
 .SECONDEXPANSION:
 %.mk: top_%.v
 	verilator ${VFLAGS} -I.. ${VERILOG_LIBS} \
-	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) \
+	    -cc $< --exe main_$(basename $@).cpp -o $(basename $@) $(VERILOG_DEBUG) \
 		-I.. -CFLAGS "${CFLAGS} ${SDL_CFLAGS} ${OPT_FLAGS}" -LDFLAGS "${SDL_LDFLAGS} ${OPT_FLAGS}"
 
 %.exe: %.mk

--- a/hardware/book/ch03/ch03.v
+++ b/hardware/book/ch03/ch03.v
@@ -40,6 +40,9 @@ module ch03 #(
 
     `define DEBUG  // debug messages in simulation (comment out to disable)
 
+    // slow Earthrise draw rate by this factor
+    localparam ER_DRAW_RATE = 10000;  // set to 1 for full speed
+
     // vram - 16K x 32-bit (64 KiB) with bit write
     //   NB. Due to bit write, minimum depth is 64 KiB with 18 Kb bram
     localparam VRAM_ADDRW = 14;  // vram address width (bits)
@@ -116,6 +119,21 @@ module ch03 #(
     wire er_busy, er_done, er_instr_invalid;  // handy for simulation
     /* verilator lint_on UNUSEDSIGNAL */
 
+    // delay counter to make drawing process visible
+    reg [$clog2(ER_DRAW_RATE)-1:0] cnt_draw_rate;
+    reg er_enable;
+    always @(posedge clk_sys) begin
+        /* verilator lint_off WIDTHEXPAND */
+        if (cnt_draw_rate == ER_DRAW_RATE - 1) begin
+        /* verilator lint_on WIDTHEXPAND */
+            cnt_draw_rate <= 0;
+            er_enable <= 1;
+        end else begin
+            cnt_draw_rate <= cnt_draw_rate + 1;
+            er_enable <= 0;
+        end
+    end
+
     earthrise #(
         .CORDW(CORDW),
         .WORD(WORD),
@@ -126,6 +144,7 @@ module ch03 #(
     ) earthrise_inst (
         .clk(clk_sys),
         .rst(rst_sys),
+        .en(er_enable),
         .start(er_start),
         .canv_w(CANV_WIDTH),
         .canv_h(CANV_HEIGHT),

--- a/hardware/book/ch03/ch03.v
+++ b/hardware/book/ch03/ch03.v
@@ -41,7 +41,7 @@ module ch03 #(
     `define DEBUG  // debug messages in simulation (comment out to disable)
 
     // slow Earthrise draw rate by this factor
-    localparam ER_DRAW_RATE = 10000;  // set to 1 for full speed
+    localparam ER_DRAW_RATE = 1;  // 1 for full speed
 
     // vram - 16K x 32-bit (64 KiB) with bit write
     //   NB. Due to bit write, minimum depth is 64 KiB with 18 Kb bram
@@ -120,12 +120,10 @@ module ch03 #(
     /* verilator lint_on UNUSEDSIGNAL */
 
     // delay counter to make drawing process visible
-    reg [$clog2(ER_DRAW_RATE)-1:0] cnt_draw_rate;
+    reg [$clog2(ER_DRAW_RATE):0] cnt_draw_rate;
     reg er_enable;
     always @(posedge clk_sys) begin
-        /* verilator lint_off WIDTHEXPAND */
         if (cnt_draw_rate == ER_DRAW_RATE - 1) begin
-        /* verilator lint_on WIDTHEXPAND */
             cnt_draw_rate <= 0;
             er_enable <= 1;
         end else begin

--- a/hardware/book/ch03/ch03.v
+++ b/hardware/book/ch03/ch03.v
@@ -154,8 +154,11 @@ module ch03 #(
         .vram_addr(draw_addr),
         .vram_din(vram_din_sys),
         .vram_wmask(vram_wmask_sys),
-        .done(er_done),
         .busy(er_busy),
+        .done(er_done),
+        /* verilator lint_off PINCONNECTEMPTY */
+        .cycle_cnt(),
+        /* verilator lint_on PINCONNECTEMPTY */
         .instr_invalid(er_instr_invalid)
     );
 

--- a/hardware/book/ch03/ch03.v
+++ b/hardware/book/ch03/ch03.v
@@ -38,8 +38,6 @@ module ch03 #(
     output reg  [BPC-1:0] disp_b            // blue display channel
     );
 
-    `define DEBUG  // debug messages in simulation (comment out to disable)
-
     // slow Earthrise draw rate by this factor
     localparam ER_DRAW_RATE = 1;  // 1 for full speed
 

--- a/hardware/docs/circle.md
+++ b/hardware/docs/circle.md
@@ -29,6 +29,5 @@ Output enable `oe` lets you pause the calculation, so you can use the `xa`, `ya`
 * `xa`, `ya` - x and y distances
 * `busy` - calculation in progress
 * `valid` - output coordinates valid
-* `done` - calculation complete (high for one tick)
 
 The output distances `xa`, `ya` are relative to the circle centre.

--- a/hardware/docs/earthrise.md
+++ b/hardware/docs/earthrise.md
@@ -54,9 +54,12 @@ For example, 2 bits per pixel mean you have 16 pixels per 32-bit word, and 16 is
 * `vram_wmask` - vram bit-write mask
 * `busy` - execution in progress
 * `done` - commands complete (high for one tick)
+* `cycle_cnt` - number of clock cycles to execute command list
 * `instr_invalid` - invalid instruction
 
 See [vram](vram.md) for details on vram write mask.
+
+You can use `cycle_cnt` to learn how many clock cycles Earthrise took to execute your command list. This isn't adjusted for enable (`en`) so, cycle counts will vary if Earthrise is sharing vram with other devices.
 
 ## Earthrise Command List
 

--- a/hardware/docs/earthrise.md
+++ b/hardware/docs/earthrise.md
@@ -23,12 +23,15 @@ _I'll add more details on the internal operation of Earthrise in future updates.
 
 * `clk` - clock
 * `rst` - reset
+* `en` - enable
 * `start` - start execution
 * `canv_w`, `canv_h` - canvas width and height (in pixels)
 * `canv_bpp` - canvas bits per pixel (colour depth)
 * `cmd_list` - command list data (2 x 16-bit instructions)
 * `addr_base` - address of first pixel in canvas
 * `addr_shift` - address shift bits
+
+The `en` signal is useful for bus arbitration and for slowing down drawing to make the process visible.
 
 `addr_base` is the base address of the canvas buffer (first pixel) in vram.
 

--- a/hardware/docs/fline.md
+++ b/hardware/docs/fline.md
@@ -32,4 +32,3 @@ Output enable `oe` lets you pause the fast line calculation, which is useful for
 * `x` - line position (output coordinate)
 * `busy` - calculation in progress
 * `valid` - output coordinates valid
-* `done` - calculation complete (high for one tick)

--- a/hardware/docs/line.md
+++ b/hardware/docs/line.md
@@ -29,9 +29,8 @@ Output enable `oe` lets you pause the line calculation, which is useful for mult
 
 * `x`, `y` - line position (output coordinates)
 * `lx` - first x-coordinate for this y
+* `fill` - ready for fill; current y complete (used by Earthrise)
 * `busy` - calculation in progress
 * `valid` - output coordinates valid
-* `fill` - ready for fill; current y complete (used by Earthrise)
-* `done` - calculation complete (high for one tick)
 
 `lx` is helpful when drawing filled triangles. When `fill` occurs, Earthrise can use `lx` or `x` depending on whether it needs the left or right pixel for this line. You can see this logic in the [Earthrise](earthrise.md) module.

--- a/hardware/docs/line.md
+++ b/hardware/docs/line.md
@@ -28,9 +28,9 @@ Output enable `oe` lets you pause the line calculation, which is useful for mult
 ### Output
 
 * `x`, `y` - line position (output coordinates)
-* `lx` - first x-coordinate for this y
+* `xs` - start x-coordinate for this y
 * `fill` - ready for fill; current y complete (used by Earthrise)
 * `busy` - calculation in progress
 * `valid` - output coordinates valid
 
-`lx` is helpful when drawing filled triangles. When `fill` occurs, Earthrise can use `lx` or `x` depending on whether it needs the left or right pixel for this line. You can see this logic in the [Earthrise](earthrise.md) module.
+`xs` is helpful when drawing filled triangles. When `fill` occurs, Earthrise can use `xs` or `x` depending on whether it needs the left or right pixel for this line. You can see this logic in the [Earthrise](earthrise.md) module.

--- a/hardware/gfx/canv_draw_agu.v
+++ b/hardware/gfx/canv_draw_agu.v
@@ -15,6 +15,7 @@ module canv_draw_agu #(
     parameter WORD=32                // machine word size (bits)
     ) (
     input  wire clk,                      // clock
+    input  wire en,                       // enable
     input  wire signed [CORDW-1:0] w,     // canvas width
     input  wire signed [CORDW-1:0] h,     // canvas height
     input  wire signed [CORDW-1:0] x,     // horizontal pixel coordinate
@@ -36,29 +37,31 @@ module canv_draw_agu #(
     reg [ADDRW-1:0] addr_base_p1, addr_base_p2;
 
     always @(posedge clk) begin
-        // stage 1
-        x_p1 <= x;  // use x in the next stage
-        clip_p1x <= (x < 0 || x > w-1);  // horizontal clip
-        clip_p1y <= (y < 0 || y > h-1);  // vertical clip
-        pix_mul_p1 <= w * y;  // unsigned result, but clip flags x<0 or y<0
-        addr_shift_p1 <= addr_shift;
-        addr_base_p1 <= addr_base;
+        if (en) begin
+            // stage 1
+            x_p1 <= x;  // use x in the next stage
+            clip_p1x <= (x < 0 || x > w-1);  // horizontal clip
+            clip_p1y <= (y < 0 || y > h-1);  // vertical clip
+            pix_mul_p1 <= w * y;  // unsigned result, but clip flags x<0 or y<0
+            addr_shift_p1 <= addr_shift;
+            addr_base_p1 <= addr_base;
 
-        // stage 2
-        clip_p2 <= clip_p1x || clip_p1y;
-        /* verilator lint_off WIDTHEXPAND */
-        pix_addr_p2 <= pix_mul_p1 + x_p1;
-        /* verilator lint_on WIDTHEXPAND */
-        addr_shift_p2 <= addr_shift_p1;
-        addr_base_p2 <= addr_base_p1;
+            // stage 2
+            clip_p2 <= clip_p1x || clip_p1y;
+            /* verilator lint_off WIDTHEXPAND */
+            pix_addr_p2 <= pix_mul_p1 + x_p1;
+            /* verilator lint_on WIDTHEXPAND */
+            addr_shift_p2 <= addr_shift_p1;
+            addr_base_p2 <= addr_base_p1;
 
-        // stage 3
-        clip <= clip_p2;
-        /* verilator lint_off WIDTHTRUNC */
-        /* verilator lint_off WIDTHEXPAND */
-        addr <= addr_base_p2 + (pix_addr_p2 >> addr_shift_p2);
-        pix_id <= pix_addr_p2 & ((1 << addr_shift_p2) - 1);
-        /* verilator lint_on WIDTHEXPAND */
-        /* verilator lint_on WIDTHTRUNC */
+            // stage 3
+            clip <= clip_p2;
+            /* verilator lint_off WIDTHTRUNC */
+            /* verilator lint_off WIDTHEXPAND */
+            addr <= addr_base_p2 + (pix_addr_p2 >> addr_shift_p2);
+            pix_id <= pix_addr_p2 & ((1 << addr_shift_p2) - 1);
+            /* verilator lint_on WIDTHEXPAND */
+            /* verilator lint_on WIDTHTRUNC */
+        end
     end
 endmodule

--- a/hardware/gfx/circle.v
+++ b/hardware/gfx/circle.v
@@ -12,9 +12,8 @@ module circle #(parameter CORDW=16) (  // signed coordinate width
     input  wire oe,     // output enable
     input  wire signed [CORDW-1:0] r0,      // radius
     output reg  signed [CORDW-1:0] xa, ya,  // x and y distances
-    output reg  busy,   // calculation in progress
-    output reg  valid,  // output coordinates valid
-    output reg  done    // calculation complete (high for one tick)
+    output wire busy,  // calculation in progress
+    output wire valid  // output coordinates valid
     );
 
     // internal variables
@@ -33,11 +32,8 @@ module circle #(parameter CORDW=16) (  // signed coordinate width
     always @(posedge clk) begin
         case (state)
             CALC_Y: begin
-                if (xa == 0) begin
-                    state <= IDLE;
-                    busy <= 0;
-                    done <= 1;
-                end else begin
+                if (xa == 0) state <= IDLE;
+                else begin
                     state <= CALC_X;
                     err_tmp <= err;  // save existing error for next step
                     /* verilator lint_off WIDTH */
@@ -60,10 +56,8 @@ module circle #(parameter CORDW=16) (  // signed coordinate width
             VALID: if (oe) state <= WAIT;
             WAIT: state <= CALC_Y;  // wait one cycle after validity so we can latch values
             default: begin  // IDLE
-                done <= 0;
                 if (start) begin
                     state <= VALID;  // first coords from input
-                    busy <= 1;
                     xa <= -r0;
                     ya <= 0;
                     err <= 2 - (2 * r0);
@@ -71,12 +65,9 @@ module circle #(parameter CORDW=16) (  // signed coordinate width
             end
         endcase
 
-        if (rst) begin
-            state <= IDLE;
-            busy <= 0;
-            done <= 0;
-        end
+        if (rst) state <= IDLE;
     end
 
-    always @(*) valid = (state == VALID);
+    assign busy  = (state != IDLE) || start;
+    assign valid = (state == VALID);
 endmodule

--- a/hardware/gfx/earthrise.v
+++ b/hardware/gfx/earthrise.v
@@ -43,12 +43,6 @@ module earthrise #(
 
     localparam ICORDW = CORDW - 4;  // use integer coordinates (4 bits reserved for fraction)
 
-    // sign extension needed for tri_b_left cross product
-    function signed [2*ICORDW+1:0] sext;
-        input signed [ICORDW-1:0] v;
-        sext = {{(ICORDW+2){v[ICORDW-1]}}, v};
-    endfunction
-
     localparam INSTRW = 16;  // instruction width (bits)
     localparam OPCW   =  4;  // opcode width (bits)
     localparam FUNW   =  4;  // function width
@@ -104,14 +98,15 @@ module earthrise #(
     wire line_a_oe, line_a_busy, line_a_valid, line_a_fill;
     reg signed [ICORDW-1:0] line_a_x0, line_a_y0;
     reg signed [ICORDW-1:0] line_a_x1, line_a_y1;
-    wire signed [ICORDW-1:0] line_a_x, line_a_y, line_a_lx;
+    reg signed [ICORDW-1:0] line_a_xlo, line_a_xhi;
+    wire signed [ICORDW-1:0] line_a_x, line_a_y, line_a_xs;
 
     // line B signals
     reg line_b_start;
     wire line_b_oe, line_b_busy, line_b_valid, line_b_fill;
     reg signed [ICORDW-1:0] line_b_x0, line_b_y0;
     reg signed [ICORDW-1:0] line_b_x1, line_b_y1;
-    wire signed [ICORDW-1:0] line_b_x, line_b_y, line_b_lx;
+    wire signed [ICORDW-1:0] line_b_x, line_b_y, line_b_xs;
 
     // fast line signals
     reg fline_start;
@@ -130,7 +125,6 @@ module earthrise #(
 
     // triangle signals
     reg tri_b_edge;   // flag: drawing edge B0 or B1
-    reg tri_b_left;   // flag: B edges are on the left
     reg tri_a_xdec;   // flag: x-coordinate is decreasing on edge A
     reg tri_b_xdec;   // flag: x-coordinate is decreasing on edge B
     reg tri_b1_skip;  // flag: skip drawing at start of edge B1
@@ -484,8 +478,6 @@ module earthrise #(
                 TRI_INIT_B0: begin  // A: tv0s -> tv2s; B0: tv0s -> tv1s
                     state <= TRI_WAIT;
                     // `debug_er($display("  sorted (%d,%d) (%d,%d) (%d,%d)", tvx0s, tvy0s, tvx1s, tvy1s, tvx2s, tvy2s));
-                    tri_b_left <= (sext(tvx1s) - sext(tvx0s))*(sext(tvy2s) - sext(tvy0s)) <  // sign extend for cross product
-                                (sext(tvy1s) - sext(tvy0s))*(sext(tvx2s) - sext(tvx0s));
                     // line A
                     line_a_x0 <= tvx0s;
                     line_a_y0 <= tvy0s;
@@ -515,7 +507,6 @@ module earthrise #(
                     line_b_start <= 1;
                 end
                 TRI_WAIT: begin
-                    // `debug_er($display("  tri_b_left=%b", tri_b_left));
                     state <= tri_b1_skip ? TRI_LINE_B : TRI_LINE_A;  // B line repeats at start of B1: jump ahead one line
                     line_a_start <= 0;  // clear start signals
                     line_b_start <= 0;
@@ -529,8 +520,8 @@ module earthrise #(
                     end
                     if (line_a_fill || (!line_a_busy)) begin
                         state <= TRI_LINE_B;
-                        if (!tri_b_left) fline_x0 <= tri_a_xdec ? line_a_lx + 1 : line_a_x + 1;
-                        else fline_x1 <= tri_a_xdec ? line_a_x - 1 : line_a_lx - 1;
+                        line_a_xlo <= tri_a_xdec ? line_a_x  : line_a_xs;  // x is leftmost with dec x
+                        line_a_xhi <= tri_a_xdec ? line_a_xs : line_a_x;   // xs is rightmost with dec x
                     end
                 end
                 TRI_LINE_B: begin
@@ -542,9 +533,15 @@ module earthrise #(
                     end
                     if (line_b_fill || (!line_b_busy)) begin
                         state <= TRI_FILL_INIT;
-                        if (tri_b_left) fline_x0 <= tri_b_xdec ? line_b_lx + 1 : line_b_x + 1;
-                        else fline_x1 <= tri_b_xdec ? line_b_x - 1 : line_b_lx - 1;
                         fline_y <= line_b_y;
+                        // is line A or B on the left-hand side?
+                        if (line_a_xlo < (tri_b_xdec ? line_b_xs : line_b_x)) begin
+                            fline_x0 <= line_a_xhi + 1;  // line A on left
+                            fline_x1 <= (tri_b_xdec ? line_b_x : line_b_xs) - 1;
+                        end else begin  // line B on left
+                            fline_x0 <= (tri_b_xdec ? line_b_xs : line_b_x) + 1;
+                            fline_x1 <= line_a_xlo - 1;
+                        end
                     end
                 end
                 TRI_FILL_INIT: begin
@@ -554,7 +551,7 @@ module earthrise #(
                         state <= TRI_NEXT_Y;
                         tri_b1_skip <= 0;
                         // `debug_er($display("  line B1 ** skip fill on first y ** - a_y=%d, b_y=%d", line_a_y, line_b_y));
-                    end else if (fline_x0 <= fline_x1) begin  // do we have a line to draw? Depends indirectly on dot product.
+                    end else if (fline_x0 <= fline_x1) begin  // do we have a filled line to draw?
                         state <= TRI_FILL_EXEC;
                         fline_start <= 1;
                         // `debug_er($display("  fline   - draw (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
@@ -565,12 +562,10 @@ module earthrise #(
                 end
                 TRI_FILL_EXEC: begin
                     if (!fline_busy) state <= TRI_NEXT_Y;
-                    else if (fline_valid) begin
-                        drawing <= 1;
-                        x <= fline_x;
-                        y <= fline_y;
-                    end
                     fline_start <= 0;
+                    drawing <= fline_valid;
+                    x <= fline_x;
+                    y <= fline_y;
                 end
                 TRI_NEXT_Y: begin
                     if (!line_b_busy) state <= tri_b_edge ? DECODE : TRI_INIT_B1;
@@ -602,6 +597,11 @@ module earthrise #(
     assign line_b_oe = (state == TRI_LINE_B);
     assign circle_oe = (state == CIRCLE_CALC);
 
+
+    //
+    // graphics primitves
+    //
+
     line #(.CORDW(ICORDW)) line_a_inst (
         .clk(clk),
         .rst(rst),
@@ -613,7 +613,7 @@ module earthrise #(
         .y1(line_a_y1),
         .x(line_a_x),
         .y(line_a_y),
-        .lx(line_a_lx),
+        .xs(line_a_xs),
         .fill(line_a_fill),
         .busy(line_a_busy),
         .valid(line_a_valid)
@@ -630,7 +630,7 @@ module earthrise #(
         .y1(line_b_y1),
         .x(line_b_x),
         .y(line_b_y),
-        .lx(line_b_lx),
+        .xs(line_b_xs),
         .fill(line_b_fill),
         .busy(line_b_busy),
         .valid(line_b_valid)

--- a/hardware/gfx/earthrise.v
+++ b/hardware/gfx/earthrise.v
@@ -142,26 +142,22 @@ module earthrise #(
     localparam DECODE         =  3;
     localparam EXEC           =  4;  // all instr use this state
     localparam LINE_EXEC      =  5;  // drawing instr have their own states
-    localparam FLINE_EXEC     =  6;
+    localparam FLINE_EXEC     =  6;  // used for fast and fill lines
     localparam RECT_INIT      =  7;
     localparam RECT_EXEC      =  8;
     localparam RECTF_INIT     =  9;
-    localparam RECTF_EXEC     = 10;
-    localparam CIRCLE_CALC    = 11;
-    localparam CIRCLE_PIX     = 12;
-    localparam CIRCLE_FILL_DI = 13;  // init circle down line
-    localparam CIRCLE_FILL_DD = 14;  // draw circle down line
-    localparam CIRCLE_FILL_UI = 15;  // init circle up line
-    localparam CIRCLE_FILL_UD = 16;  // draw circle up line
-    localparam TRI_INIT_B0    = 17;
-    localparam TRI_INIT_B1    = 18;
-    localparam TRI_WAIT       = 19;
-    localparam TRI_LINE_A     = 20;
-    localparam TRI_LINE_B     = 21;
-    localparam TRI_FILL_INIT  = 22;
-    localparam TRI_FILL_EXEC  = 23;
-    localparam TRI_NEXT_Y     = 24;
-    localparam JUMP_WAIT      = 25;
+    localparam CIRCLE_CALC    = 10;
+    localparam CIRCLE_PIX     = 11;
+    localparam CIRCLE_FILL_DN = 12;
+    localparam CIRCLE_FILL_UP = 13;
+    localparam TRI_INIT_B0    = 14;
+    localparam TRI_INIT_B1    = 15;
+    localparam TRI_WAIT       = 16;
+    localparam TRI_LINE_A     = 17;
+    localparam TRI_LINE_B     = 18;
+    localparam TRI_FILL_INIT  = 19;
+    localparam TRI_NEXT_Y     = 20;
+    localparam JUMP_WAIT      = 21;
 
     localparam STATEW = 5;  // state width (bits)
     reg [STATEW-1:0] state, state_return;
@@ -293,6 +289,7 @@ module earthrise #(
                                 'h1: begin  // draw line
                                     if (tvy0 == tvy1) begin  // fast line
                                         state <= FLINE_EXEC;
+                                        state_return <= DECODE;
                                         fline_start <= 1;
                                         fline_x0 <= tvx0;
                                         fline_x1 <= tvx1;
@@ -365,7 +362,7 @@ module earthrise #(
                     if (circle_valid) begin  // register the result before leaving CIRCLE_CALC
                         circle_x_offs <= circle_xa;
                         circle_y_offs <= circle_ya;
-                        state <= (imm8[OPT_FILL] == 0) ? CIRCLE_PIX : CIRCLE_FILL_DI;
+                        state <= (imm8[OPT_FILL] == 0) ? CIRCLE_PIX : CIRCLE_FILL_DN;
                     end
                     circle_start <= 0;
                 end
@@ -380,34 +377,22 @@ module earthrise #(
                         'd3: begin x <= circle_x0 - circle_x_offs; end
                     endcase
                 end
-                CIRCLE_FILL_DI: begin
-                    state <= CIRCLE_FILL_DD;
+                CIRCLE_FILL_DN: begin
+                    state <= FLINE_EXEC;
+                    state_return <= CIRCLE_FILL_UP;
                     fline_start <= 1;
                     fline_y  <= circle_y0 + circle_y_offs;
                     fline_x0 <= circle_x0 + circle_x_offs;
                     fline_x1 <= circle_x0 - circle_x_offs;
                 end
-                CIRCLE_FILL_DD: begin
-                    if (!fline_busy) state <= CIRCLE_FILL_UI;
-                    fline_start <= 0;
-                    drawing <= fline_valid;
-                    x <= fline_x;
-                    y <= fline_y;
-                end
-                CIRCLE_FILL_UI: begin
-                    state <= CIRCLE_FILL_UD;
+                CIRCLE_FILL_UP: begin  // fline_x0,fline_x1 unchanged from CIRCLE_FILL_DN
+                    state <= FLINE_EXEC;
+                    state_return <= circle_busy ? CIRCLE_CALC : DECODE;
                     fline_start <= 1;
-                    fline_y  <= circle_y0 - circle_y_offs;
-                end
-                CIRCLE_FILL_UD: begin  // almost duplicate of CIRCLE_FILL_DD - could we use return state?
-                    if (!fline_busy) state <= circle_busy ? CIRCLE_CALC : DECODE;
-                    fline_start <= 0;
-                    drawing <= fline_valid;
-                    x <= fline_x;
-                    y <= fline_y;
+                    fline_y <= circle_y0 - circle_y_offs;
                 end
                 FLINE_EXEC: begin
-                    if (!fline_busy) state <= DECODE;
+                    if (!fline_busy) state <= state_return;
                     fline_start <= 0;
                     drawing <= fline_valid;
                     x <= fline_x;
@@ -461,19 +446,12 @@ module earthrise #(
                 end
                 RECTF_INIT: begin
                     cnt_fill <= cnt_fill + 1;
-                    state <= RECTF_EXEC;
+                    state <= FLINE_EXEC;
                     state_return <= (tvy0s + cnt_fill < tvy1s) ? RECTF_INIT : DECODE;
                     fline_start <= 1;
                     fline_y  <= tvy0s + cnt_fill;
                     fline_x0 <= tvx0s;
                     fline_x1 <= tvx1s;
-                end
-                RECTF_EXEC: begin
-                    if (!fline_busy) state <= state_return;
-                    fline_start <= 0;
-                    drawing <= fline_valid;
-                    x <= fline_x;
-                    y <= fline_y;
                 end
                 TRI_INIT_B0: begin  // A: tv0s -> tv2s; B0: tv0s -> tv1s
                     state <= TRI_WAIT;
@@ -552,20 +530,14 @@ module earthrise #(
                         tri_b1_skip <= 0;
                         // `debug_er($display("  line B1 ** skip fill on first y ** - a_y=%d, b_y=%d", line_a_y, line_b_y));
                     end else if (fline_x0 <= fline_x1) begin  // do we have a filled line to draw?
-                        state <= TRI_FILL_EXEC;
+                        state <= FLINE_EXEC;
+                        state_return <= TRI_NEXT_Y;
                         fline_start <= 1;
                         // `debug_er($display("  fline   - draw (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
                     end else begin
                         state <= TRI_NEXT_Y;
                         // `debug_er($display("  fline   - no   (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
                     end
-                end
-                TRI_FILL_EXEC: begin
-                    if (!fline_busy) state <= TRI_NEXT_Y;
-                    fline_start <= 0;
-                    drawing <= fline_valid;
-                    x <= fline_x;
-                    y <= fline_y;
                 end
                 TRI_NEXT_Y: begin
                     if (!line_b_busy) state <= tri_b_edge ? DECODE : TRI_INIT_B1;

--- a/hardware/gfx/earthrise.v
+++ b/hardware/gfx/earthrise.v
@@ -18,6 +18,7 @@ module earthrise #(
     ) (
     input  wire clk,                           // clock
     input  wire rst,                           // reset
+    input  wire en,                            // enable
     input  wire start,                         // start execution
     input  wire signed [CORDW-1:0] canv_w,     // canvas width
     input  wire signed [CORDW-1:0] canv_h,     // canvas height
@@ -174,412 +175,29 @@ module earthrise #(
     // select instruction from command list data (upper or lower half from word)
     wire [INSTRW-1:0] instr = pc[1] ? cmd_list[2*INSTRW-1:INSTRW] : cmd_list[INSTRW-1:0];
 
+    // latch start and done signals so we can act on them later if !en
+    reg start_pending;
     always @(posedge clk) begin
-        drawing <= 0;
-        case (state)
-            JUMP_WAIT: state <= FETCH;  // wait an extra cycle after changing PC before we can fetch
-            FETCH: state <= DECODE;
-            DECODE: begin
-                if (pc_reg[ER_ADDRW+2]) state <= DONE;  // stop if overflow bit of PC set
-                else begin
-                    state <= EXEC;
-                    pc_reg <= pc_reg + 2;  // next instruction by default (16-bit instr)
-                    pc_debug <= pc_reg[ER_ADDRW+1:0];  // save address of current instr for debug
-                    opc <= instr[INSTRW-1:INSTRW-OPCW];
-                    imm12 <= instr[IMM12-1:0];
-                    fun <= instr[COLRW+FUNW-1:COLRW];
-                    imm8 <= instr[IMM8-1:0];
-                    cnt_draw <= 0;  // draw counter
-                    cnt_fill <= 0;  // fill counter
-                    // `debug_er($display(">> decode  %x - instr: %x", pc, instr));
-                end
-            end
-            EXEC: begin
-                state <= FETCH;
-                case (opc)
-                    'h0: tvx0 <= imm12 + xt;  // translated vertex x0
-                    'h1: tvy0 <= imm12 + yt;
-                    'h2: begin
-                        r0  <= imm12;  // radius r0 (not translated)
-                        tvx1 <= imm12 + xt;  // translated vertex x1
-                    end
-                    'h3: tvy1 <= imm12 + yt;
-                    'h4: tvx2 <= imm12 + xt;
-                    'h5: tvy2 <= imm12 + yt;
-                    'h6: tvx3 <= imm12 + xt;
-                    'h7: tvy3 <= imm12 + yt;
-                    'h8: xt   <= imm12;
-                    'h9: yt   <= imm12;
-                    'hA: begin
-                        pc_start <= imm12[ER_ADDRW+1:0];
-                        `debug_er($display("0x%x: pc_next  %x", pc_debug, imm12[ER_ADDRW-1:0]));
-                    end
-                    'hC: begin  // colour and control
-                        case (fun)
-                            'h0: begin
-                                lca <= imm8;
-                                `debug_er($display("0x%x: lca      %x", pc_debug, imm8));
-                            end
-                            'h1: begin
-                                lcb <= imm8;
-                                `debug_er($display("0x%x: lcb      %x", pc_debug, imm8));
-                            end
-                            'h2: begin
-                                fca <= imm8;
-                                `debug_er($display("0x%x: fca      %x", pc_debug, imm8));
-                            end
-                            'h3: begin
-                                fcb <= imm8;
-                                `debug_er($display("0x%x: fcb      %x", pc_debug, imm8));
-                            end
-                            'hA: begin  // 0xCA - Jump (Change Address)
-                                state <= JUMP_WAIT;  // wait a cycle after changing PC
-                                pc_reg <= {1'b0, pc_start};
-                                `debug_er($display("0x%x: jump     %x", pc_debug, pc_start));
-                            end
-                            'hC: begin  // 0xCC - NOP (Continue)
-                                state <= FETCH;
-                            end
-                            'hE: begin  // 0xCE Stop (CEase)
-                                state <= DONE;
-                                `debug_er($display("0x%x: stop", pc_debug));  // use pc_debug because pc points at NEXT instruction
-                            end
-                            default: begin
-                                state <= DONE;
-                                instr_invalid <= 1;
-                                `debug_er($display("0x%x: Invalid Instruction - no such instruction '0xC%x'.", pc_debug, fun));
-                            end
-                        endcase
-                    end
-                    'hD: begin
-                        // handle colour once for all shapes; fill colours work for shapes without filled forms
-                        colr <= imm8[OPT_FILL] ? (imm8[OPT_COLR] ? fcb : fca)
-                                               : (imm8[OPT_COLR] ? lcb : lca);
+        if (rst) start_pending <= 0;
+        else if (start) start_pending <= 1;
+        else if (state == IDLE && en) start_pending <= 0;
+    end
 
-                        // disable line output by default
-                        line_a_oe <= 0;
-                        line_b_oe <= 0;
+    reg line_a_done_latch;
+    always @(posedge clk) begin
+        if (rst) line_a_done_latch <= 0;
+        else if (line_a_done) line_a_done_latch <= 1;
+        else if (en) line_a_done_latch <= 0;
+    end
 
-                        // select drawing function
-                        case (fun)
-                            'h0: begin  // draw pixel
-                                x <= tvx0;
-                                y <= tvy0;
-                                drawing <= 1;
-                                `debug_er($display("0x%x: pixel    (%d,%d)", pc_debug, tvx0, tvy0));
-                            end
-                            'h1: begin  // draw line
-                                if (tvy0 == tvy1) begin  // fast line
-                                    state <= FLINE_EXEC;
-                                    fline_start <= 1;
-                                    fline_x0 <= tvx0;
-                                    fline_x1 <= tvx1;
-                                    fline_y <= tvy0;  // use tvy0 for vertical position
-                                    `debug_er($display("0x%x: fline    (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
-                                end else begin
-                                    state <= LINE_EXEC;
-                                    line_a_oe <= 1;
-                                    line_a_start <= 1;   // use line instance A
-                                    line_a_x0 <= tvx0;
-                                    line_a_y0 <= tvy0;
-                                    line_a_x1 <= tvx1;
-                                    line_a_y1 <= tvy1;
-                                    `debug_er($display("0x%x: line     (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
-                                end
-                            end
-                            'h2: begin  // draw circle
-                                if (r0 > 0) begin  // only draw with positive radius
-                                    state <= CIRCLE_CALC;
-                                    circle_start <= 1;
-                                    circle_x0 <= tvx0;
-                                    circle_y0 <= tvy0;
-                                    circle_r0 <= r0;
-                                end else state <= FETCH;
-                                `debug_er($display("0x%x: circle   (%d,%d) r=%d", pc_debug, tvx0, tvy0, r0));
-                            end
-                            'h3: begin  // draw triangle (sort vertices first)
-                                if (tri_min == tri_max || tri_degen_x) begin  // degenerate triangle
-                                    state <= DONE;
-                                    instr_invalid <= 1;
-                                    `debug_er($display("0x%x: Invalid Instruction - degenerate triangle.", pc_debug));
-                                end else state <= TRI_INIT_B0;
-                                tvx0s <= (tri_min == 0) ? tvx0 : (tri_min == 1) ? tvx1 : tvx2;
-                                tvy0s <= (tri_min == 0) ? tvy0 : (tri_min == 1) ? tvy1 : tvy2;
-                                tvx1s <= (tri_mid == 0) ? tvx0 : (tri_mid == 1) ? tvx1 : tvx2;
-                                tvy1s <= (tri_mid == 0) ? tvy0 : (tri_mid == 1) ? tvy1 : tvy2;
-                                tvx2s <= (tri_max == 0) ? tvx0 : (tri_max == 1) ? tvx1 : tvx2;
-                                tvy2s <= (tri_max == 0) ? tvy0 : (tri_max == 1) ? tvy1 : tvy2;
-                                `debug_er($display("0x%x: triangle (%d,%d) (%d,%d) (%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1, tvx2, tvy2));
-                            end
-                            'h4: begin  // draw rect (sort vertices first)
-                                tvx0s <= (tvx0 < tvx1) ? tvx0 : tvx1;
-                                tvy0s <= (tvy0 < tvy1) ? tvy0 : tvy1;
-                                tvx1s <= (tvx0 < tvx1) ? tvx1 : tvx0;
-                                tvy1s <= (tvy0 < tvy1) ? tvy1 : tvy0;
-                                state <= (imm8[OPT_FILL] == 0) ? RECT_INIT : RECTF_INIT;
-                                `debug_er($display("0x%x: rect     (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
-                            end
-                            default: begin
-                                state <= DONE;
-                                instr_invalid <= 1;
-                                `debug_er($display("0x%x: Invalid Instruction - no such draw function '%x'.", pc_debug, fun));
-                            end
-                        endcase
-                    end
-                    default: begin
-                        state <= DONE;
-                        instr_invalid <= 1;
-                        `debug_er($display("0x%x: Invalid Instruction - no such opcode '%x'.", pc_debug, opc));
-                    end
-                endcase
-            end
-            LINE_EXEC: begin
-                if (line_a_done) state <= DECODE;
-                line_a_start <= 0;
-                drawing <= line_a_valid;
-                x <= line_a_x;
-                y <= line_a_y;
-            end
-            CIRCLE_CALC: begin
-                if (circle_valid) begin
-                    // register the result because circle calc keeps going due to oe implementation
-                    circle_x_offs <= circle_xa;
-                    circle_y_offs <= circle_ya;
-                    state <= (imm8[OPT_FILL] == 0) ? CIRCLE_PIX : CIRCLE_FILL_DI;
-                end
-                circle_start <= 0;
-            end
-            CIRCLE_PIX: begin
-                if (cnt_draw == 3) state <= (circle_busy) ? CIRCLE_CALC : DECODE;
-                drawing <= 1;
-                cnt_draw <= cnt_draw + 1;
-                case (cnt_draw)
-                    'd0: begin x <= circle_x0 - circle_x_offs; y <= circle_y0 + circle_y_offs; end
-                    'd1: begin x <= circle_x0 + circle_x_offs; end
-                    'd2: begin y <= circle_y0 - circle_y_offs; end
-                    'd3: begin x <= circle_x0 - circle_x_offs; end
-                endcase
-            end
-            CIRCLE_FILL_DI: begin
-                state <= CIRCLE_FILL_DD;
-                fline_start <= 1;
-                fline_y  <= circle_y0 + circle_y_offs;
-                fline_x0 <= circle_x0 + circle_x_offs;
-                fline_x1 <= circle_x0 - circle_x_offs;
-            end
-            CIRCLE_FILL_DD: begin
-                if (fline_done) state <= CIRCLE_FILL_UI;
-                fline_start <= 0;
-                drawing <= fline_valid;
-                x <= fline_x;
-                y <= fline_y;
-            end
-            CIRCLE_FILL_UI: begin
-                state <= CIRCLE_FILL_UD;
-                fline_start <= 1;
-                fline_y  <= circle_y0 - circle_y_offs;
-            end
-            CIRCLE_FILL_UD: begin  // almost duplicate of CIRCLE_FILL_DD - could we use return state?
-                if (fline_done) state <= (circle_busy) ? CIRCLE_CALC : DECODE;
-                fline_start <= 0;
-                drawing <= fline_valid;
-                x <= fline_x;
-                y <= fline_y;
-            end
-            FLINE_EXEC: begin
-                if (fline_done) state <= DECODE;
-                fline_start <= 0;
-                drawing <= fline_valid;
-                x <= fline_x;
-                y <= fline_y;
-            end
-            RECT_INIT: begin
-                state <= RECT_EXEC;
-                line_a_oe <= 1;
-                line_a_start <= 1;
-                cnt_draw <= cnt_draw + 1;
-                case (cnt_draw)
-                    'd0: begin
-                        state_return <= RECT_INIT;  // return for second edge
-                        line_a_x0 <= tvx0s;
-                        line_a_y0 <= tvy0s;
-                        line_a_x1 <= tvx1s;
-                        line_a_y1 <= tvy0s;
-                        // `debug_er($display("  0: (%d,%d) -> (%d,%d)", tvx0s, tvy0s, tvx1s, tvy0s));
-                    end
-                    'd1: begin
-                        state_return <= RECT_INIT;  // return for third edge
-                        line_a_x0 <= tvx0s;
-                        line_a_y0 <= tvy1s;
-                        line_a_x1 <= tvx1s;
-                        line_a_y1 <= tvy1s;
-                        // `debug_er($display("  1: (%d,%d) -> (%d,%d)", tvx0s, tvy1s, tvx1s, tvy1s));
-                    end
-                    'd2: begin
-                        state_return <= RECT_INIT;  // return for fourth edge
-                        line_a_x0 <= tvx0s;
-                        line_a_y0 <= tvy0s;
-                        line_a_x1 <= tvx0s;
-                        line_a_y1 <= tvy1s;
-                        // `debug_er($display("  2: (%d,%d) -> (%d,%d)", tvx0s, tvy0s, tvx0s, tvy1s));
-                    end
-                    default: begin
-                        state_return <= DECODE;  // decode next instruction after draw
-                        line_a_x0 <= tvx1s;
-                        line_a_y0 <= tvy0s;
-                        line_a_x1 <= tvx1s;
-                        line_a_y1 <= tvy1s;
-                        // `debug_er($display("  3: (%d,%d) -> (%d,%d)", tvx1s, tvy0s, tvx1s, tvy1s));
-                    end
-                endcase
-            end
-            RECT_EXEC: begin
-                if (line_a_done) state <= state_return;
-                line_a_start <= 0;
-                drawing <= line_a_valid;
-                x <= line_a_x;
-                y <= line_a_y;
-            end
-            RECTF_INIT: begin
-                cnt_fill <= cnt_fill + 1;
-                state <= RECTF_EXEC;
-                state_return <= (tvy0s + cnt_fill < tvy1s) ? RECTF_INIT : DECODE;
-                fline_start <= 1;
-                fline_y  <= tvy0s + cnt_fill;
-                fline_x0 <= tvx0s;
-                fline_x1 <= tvx1s;
-            end
-            RECTF_EXEC: begin
-                if (fline_done) state <= state_return;
-                fline_start <= 0;
-                drawing <= fline_valid;
-                x <= fline_x;
-                y <= fline_y;
-            end
-            TRI_INIT_B0: begin  // A: tv0s -> tv2s; B0: tv0s -> tv1s
-                state <= TRI_WAIT;
-                // `debug_er($display("  sorted (%d,%d) (%d,%d) (%d,%d)", tvx0s, tvy0s, tvx1s, tvy1s, tvx2s, tvy2s));
-                tri_b_left <= (sext(tvx1s) - sext(tvx0s))*(sext(tvy2s) - sext(tvy0s)) <  // sign extend for cross product
-                              (sext(tvy1s) - sext(tvy0s))*(sext(tvx2s) - sext(tvx0s));
-                // line A
-                line_a_x0 <= tvx0s;
-                line_a_y0 <= tvy0s;
-                line_a_x1 <= tvx2s;
-                line_a_y1 <= tvy2s;
-                tri_a_xdec <= (tvx0s > tvx2s);  // does x decrease as we draw A?
-                line_a_start <= 1;
-                // line B0
-                line_b_x0 <= tvx0s;
-                line_b_y0 <= tvy0s;
-                line_b_x1 <= tvx1s;
-                line_b_y1 <= tvy1s;
-                tri_b_edge <= 0;
-                tri_b_xdec <= (tvx0s > tvx1s);  // does x decrease as we draw B0?
-                tri_b1_skip <= 0;  // no skip on B0
-                line_b_start <= 1;
-            end
-            TRI_INIT_B1: begin  // B1: tv1s -> tv2s
-                state <= TRI_WAIT;
-                line_b_x0 <= tvx1s;
-                line_b_y0 <= tvy1s;
-                line_b_x1 <= tvx2s;
-                line_b_y1 <= tvy2s;
-                tri_b_edge <= 1;
-                tri_b_xdec <= (tvx1s > tvx2s);  // does x decrease as we draw?
-                tri_b1_skip <= 1;  // skip for y for B1 (handled by end of B0)
-                line_b_start <= 1;
-            end
-            TRI_WAIT: begin
-                // `debug_er($display("  tri_b_left=%b", tri_b_left));
-                if (tri_b1_skip) begin  // B line repeats at start of B1: jump ahead one line
-                    state <= TRI_LINE_B;
-                    line_b_oe <= 1;
-                end else begin
-                    state <= TRI_LINE_A;
-                    line_a_oe <= 1;
-                end
-                line_a_start <= 0;  // clear start signals
-                line_b_start <= 0;
-            end
-            TRI_LINE_A: begin
-                if (line_a_valid) begin
-                    drawing <= 1;
-                    x <= line_a_x;
-                    y <= line_a_y;
-                    // `debug_er($display("  line A  - draw (%d,%d)", line_a_x, line_a_y));
-                end
-                if (line_a_fill || (!line_a_busy)) begin
-                    state <= TRI_LINE_B;
-                    if (!tri_b_left) fline_x0 <= tri_a_xdec ? line_a_lx + 1 : line_a_x + 1;
-                    else fline_x1 <= tri_a_xdec ? line_a_x - 1 : line_a_lx - 1;
-                    line_a_oe <= 0;
-                    line_b_oe <= 1;
-                end
-            end
-            TRI_LINE_B: begin
-                if (line_b_valid) begin
-                    drawing <= 1;
-                    x <= line_b_x;
-                    y <= line_b_y;
-                    // `debug_er($display("  line B%b - draw (%d,%d)", tri_b_edge, line_b_x, line_b_y));
-                end
-                if (line_b_fill || (!line_b_busy)) begin
-                    state <= TRI_FILL_INIT;
-                    if (tri_b_left) fline_x0 <= tri_b_xdec ? line_b_lx + 1 : line_b_x + 1;
-                    else fline_x1 <= tri_b_xdec ? line_b_x - 1 : line_b_lx - 1;
-                    fline_y <= line_b_y;
-                    line_b_oe <= 0;
-                end
-            end
-            TRI_FILL_INIT: begin
-                if (imm8[OPT_FILL] == 0 || (line_a_busy | line_b_busy) == 0) begin  // skip if unfilled or both lines are done
-                    state <= TRI_NEXT_Y;
-                end else if (tri_b1_skip == 1) begin
-                    state <= TRI_NEXT_Y;
-                    tri_b1_skip <= 0;
-                    // `debug_er($display("  line B1 ** skip fill on first y ** - a_y=%d, b_y=%d", line_a_y, line_b_y));
-                end else if (fline_x0 <= fline_x1) begin  // do we have a line to draw? Depends indirectly on dot product.
-                    state <= TRI_FILL_EXEC;
-                    fline_start <= 1;
-                    // `debug_er($display("  fline   - draw (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
-                end else begin
-                    state <= TRI_NEXT_Y;
-                    // `debug_er($display("  fline   - no   (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
-                end
-            end
-            TRI_FILL_EXEC: begin
-                if (fline_done) state <= TRI_NEXT_Y;
-                else if (fline_valid) begin
-                    drawing <= 1;
-                    x <= fline_x;
-                    y <= fline_y;
-                end
-                fline_start <= 0;
-            end
-            TRI_NEXT_Y: begin
-                if (!line_b_busy) state <= (tri_b_edge == 0) ? TRI_INIT_B1 : DECODE;
-                else begin
-                    state <= TRI_LINE_A;
-                    line_a_oe <= 1;
-                end
-                // `debug_er($display("  -- next tri line --"));
-            end
-            DONE: begin
-                state <= IDLE;
-                busy <= 0;
-                pc_reg <= 0;  // reset pc: execution always starts from address 0
-                pc_debug <= 0;
-                `debug_er($display("** DONE **"));
-            end
-            default: begin // IDLE
-                busy <= 0;
-                if (start) begin
-                    state <= FETCH;
-                    instr_invalid <= 0;
-                    busy <= 1;
-                end
-            end
-        endcase
+    reg fline_done_latch;
+    always @(posedge clk) begin
+        if (rst) fline_done_latch <= 0;
+        else if (fline_done) fline_done_latch <= 1;
+        else if (en) fline_done_latch <= 0;
+    end
+
+    always @(posedge clk) begin
         if (rst) begin
             state <= IDLE;
             state_return <= IDLE;
@@ -601,6 +219,413 @@ module earthrise #(
             // initialise translate coords to 0 to play nice in simulation
             xt <= 0;
             yt <= 0;
+        end else if (en) begin
+            drawing <= 0;
+
+            case (state)
+                JUMP_WAIT: state <= FETCH;  // wait an extra cycle after changing PC before we can fetch
+                FETCH: state <= DECODE;
+                DECODE: begin
+                    if (pc_reg[ER_ADDRW+2]) state <= DONE;  // stop if overflow bit of PC set
+                    else begin
+                        state <= EXEC;
+                        pc_reg <= pc_reg + 2;  // next instruction by default (16-bit instr)
+                        pc_debug <= pc_reg[ER_ADDRW+1:0];  // save address of current instr for debug
+                        opc <= instr[INSTRW-1:INSTRW-OPCW];
+                        imm12 <= instr[IMM12-1:0];
+                        fun <= instr[COLRW+FUNW-1:COLRW];
+                        imm8 <= instr[IMM8-1:0];
+                        cnt_draw <= 0;  // draw counter
+                        cnt_fill <= 0;  // fill counter
+                        // `debug_er($display(">> decode  %x - instr: %x", pc, instr));
+                    end
+                end
+                EXEC: begin
+                    state <= FETCH;
+                    case (opc)
+                        'h0: tvx0 <= imm12 + xt;  // translated vertex x0
+                        'h1: tvy0 <= imm12 + yt;
+                        'h2: begin
+                            r0  <= imm12;  // radius r0 (not translated)
+                            tvx1 <= imm12 + xt;  // translated vertex x1
+                        end
+                        'h3: tvy1 <= imm12 + yt;
+                        'h4: tvx2 <= imm12 + xt;
+                        'h5: tvy2 <= imm12 + yt;
+                        'h6: tvx3 <= imm12 + xt;
+                        'h7: tvy3 <= imm12 + yt;
+                        'h8: xt   <= imm12;
+                        'h9: yt   <= imm12;
+                        'hA: begin
+                            pc_start <= imm12[ER_ADDRW+1:0];
+                            `debug_er($display("0x%x: pc_next  %x", pc_debug, imm12[ER_ADDRW-1:0]));
+                        end
+                        'hC: begin  // colour and control
+                            case (fun)
+                                'h0: begin
+                                    lca <= imm8;
+                                    `debug_er($display("0x%x: lca      %x", pc_debug, imm8));
+                                end
+                                'h1: begin
+                                    lcb <= imm8;
+                                    `debug_er($display("0x%x: lcb      %x", pc_debug, imm8));
+                                end
+                                'h2: begin
+                                    fca <= imm8;
+                                    `debug_er($display("0x%x: fca      %x", pc_debug, imm8));
+                                end
+                                'h3: begin
+                                    fcb <= imm8;
+                                    `debug_er($display("0x%x: fcb      %x", pc_debug, imm8));
+                                end
+                                'hA: begin  // 0xCA - Jump (Change Address)
+                                    state <= JUMP_WAIT;  // wait a cycle after changing PC
+                                    pc_reg <= {1'b0, pc_start};
+                                    `debug_er($display("0x%x: jump     %x", pc_debug, pc_start));
+                                end
+                                'hC: begin  // 0xCC - NOP (Continue)
+                                    state <= FETCH;
+                                end
+                                'hE: begin  // 0xCE Stop (CEase)
+                                    state <= DONE;
+                                    `debug_er($display("0x%x: stop", pc_debug));  // use pc_debug because pc points at NEXT instruction
+                                end
+                                default: begin
+                                    state <= DONE;
+                                    instr_invalid <= 1;
+                                    `debug_er($display("0x%x: Invalid Instruction - no such instruction '0xC%x'.", pc_debug, fun));
+                                end
+                            endcase
+                        end
+                        'hD: begin
+                            // handle colour once for all shapes; fill colours work for shapes without filled forms
+                            colr <= imm8[OPT_FILL] ? (imm8[OPT_COLR] ? fcb : fca)
+                                                : (imm8[OPT_COLR] ? lcb : lca);
+
+                            // disable line output by default
+                            line_a_oe <= 0;
+                            line_b_oe <= 0;
+
+                            // select drawing function
+                            case (fun)
+                                'h0: begin  // draw pixel
+                                    x <= tvx0;
+                                    y <= tvy0;
+                                    drawing <= 1;
+                                    `debug_er($display("0x%x: pixel    (%d,%d)", pc_debug, tvx0, tvy0));
+                                end
+                                'h1: begin  // draw line
+                                    if (tvy0 == tvy1) begin  // fast line
+                                        state <= FLINE_EXEC;
+                                        fline_start <= 1;
+                                        fline_x0 <= tvx0;
+                                        fline_x1 <= tvx1;
+                                        fline_y <= tvy0;  // use tvy0 for vertical position
+                                        `debug_er($display("0x%x: fline    (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
+                                    end else begin
+                                        state <= LINE_EXEC;
+                                        line_a_oe <= 1;
+                                        line_a_start <= 1;   // use line instance A
+                                        line_a_x0 <= tvx0;
+                                        line_a_y0 <= tvy0;
+                                        line_a_x1 <= tvx1;
+                                        line_a_y1 <= tvy1;
+                                        `debug_er($display("0x%x: line     (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
+                                    end
+                                end
+                                'h2: begin  // draw circle
+                                    if (r0 > 0) begin  // only draw with positive radius
+                                        state <= CIRCLE_CALC;
+                                        circle_start <= 1;
+                                        circle_x0 <= tvx0;
+                                        circle_y0 <= tvy0;
+                                        circle_r0 <= r0;
+                                    end else state <= FETCH;
+                                    `debug_er($display("0x%x: circle   (%d,%d) r=%d", pc_debug, tvx0, tvy0, r0));
+                                end
+                                'h3: begin  // draw triangle (sort vertices first)
+                                    if (tri_min == tri_max || tri_degen_x) begin  // degenerate triangle
+                                        state <= DONE;
+                                        instr_invalid <= 1;
+                                        `debug_er($display("0x%x: Invalid Instruction - degenerate triangle.", pc_debug));
+                                    end else state <= TRI_INIT_B0;
+                                    tvx0s <= (tri_min == 0) ? tvx0 : (tri_min == 1) ? tvx1 : tvx2;
+                                    tvy0s <= (tri_min == 0) ? tvy0 : (tri_min == 1) ? tvy1 : tvy2;
+                                    tvx1s <= (tri_mid == 0) ? tvx0 : (tri_mid == 1) ? tvx1 : tvx2;
+                                    tvy1s <= (tri_mid == 0) ? tvy0 : (tri_mid == 1) ? tvy1 : tvy2;
+                                    tvx2s <= (tri_max == 0) ? tvx0 : (tri_max == 1) ? tvx1 : tvx2;
+                                    tvy2s <= (tri_max == 0) ? tvy0 : (tri_max == 1) ? tvy1 : tvy2;
+                                    `debug_er($display("0x%x: triangle (%d,%d) (%d,%d) (%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1, tvx2, tvy2));
+                                end
+                                'h4: begin  // draw rect (sort vertices first)
+                                    tvx0s <= (tvx0 < tvx1) ? tvx0 : tvx1;
+                                    tvy0s <= (tvy0 < tvy1) ? tvy0 : tvy1;
+                                    tvx1s <= (tvx0 < tvx1) ? tvx1 : tvx0;
+                                    tvy1s <= (tvy0 < tvy1) ? tvy1 : tvy0;
+                                    state <= (imm8[OPT_FILL] == 0) ? RECT_INIT : RECTF_INIT;
+                                    `debug_er($display("0x%x: rect     (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
+                                end
+                                default: begin
+                                    state <= DONE;
+                                    instr_invalid <= 1;
+                                    `debug_er($display("0x%x: Invalid Instruction - no such draw function '%x'.", pc_debug, fun));
+                                end
+                            endcase
+                        end
+                        default: begin
+                            state <= DONE;
+                            instr_invalid <= 1;
+                            `debug_er($display("0x%x: Invalid Instruction - no such opcode '%x'.", pc_debug, opc));
+                        end
+                    endcase
+                end
+                LINE_EXEC: begin
+                    if (line_a_done_latch) state <= DECODE;
+                    line_a_start <= 0;
+                    drawing <= line_a_valid;
+                    x <= line_a_x;
+                    y <= line_a_y;
+                end
+                CIRCLE_CALC: begin
+                    if (circle_valid) begin
+                        // register the result because circle calc keeps going due to oe implementation
+                        circle_x_offs <= circle_xa;
+                        circle_y_offs <= circle_ya;
+                        state <= (imm8[OPT_FILL] == 0) ? CIRCLE_PIX : CIRCLE_FILL_DI;
+                    end
+                    circle_start <= 0;
+                end
+                CIRCLE_PIX: begin
+                    if (cnt_draw == 3) state <= (circle_busy) ? CIRCLE_CALC : DECODE;
+                    drawing <= 1;
+                    cnt_draw <= cnt_draw + 1;
+                    case (cnt_draw)
+                        'd0: begin x <= circle_x0 - circle_x_offs; y <= circle_y0 + circle_y_offs; end
+                        'd1: begin x <= circle_x0 + circle_x_offs; end
+                        'd2: begin y <= circle_y0 - circle_y_offs; end
+                        'd3: begin x <= circle_x0 - circle_x_offs; end
+                    endcase
+                end
+                CIRCLE_FILL_DI: begin
+                    state <= CIRCLE_FILL_DD;
+                    fline_start <= 1;
+                    fline_y  <= circle_y0 + circle_y_offs;
+                    fline_x0 <= circle_x0 + circle_x_offs;
+                    fline_x1 <= circle_x0 - circle_x_offs;
+                end
+                CIRCLE_FILL_DD: begin
+                    if (fline_done_latch) state <= CIRCLE_FILL_UI;
+                    fline_start <= 0;
+                    drawing <= fline_valid;
+                    x <= fline_x;
+                    y <= fline_y;
+                end
+                CIRCLE_FILL_UI: begin
+                    state <= CIRCLE_FILL_UD;
+                    fline_start <= 1;
+                    fline_y  <= circle_y0 - circle_y_offs;
+                end
+                CIRCLE_FILL_UD: begin  // almost duplicate of CIRCLE_FILL_DD - could we use return state?
+                    if (fline_done_latch) state <= (circle_busy) ? CIRCLE_CALC : DECODE;
+                    fline_start <= 0;
+                    drawing <= fline_valid;
+                    x <= fline_x;
+                    y <= fline_y;
+                end
+                FLINE_EXEC: begin
+                    if (fline_done_latch) state <= DECODE;
+                    fline_start <= 0;
+                    drawing <= fline_valid;
+                    x <= fline_x;
+                    y <= fline_y;
+                end
+                RECT_INIT: begin
+                    state <= RECT_EXEC;
+                    line_a_oe <= 1;
+                    line_a_start <= 1;
+                    cnt_draw <= cnt_draw + 1;
+                    case (cnt_draw)
+                        'd0: begin
+                            state_return <= RECT_INIT;  // return for second edge
+                            line_a_x0 <= tvx0s;
+                            line_a_y0 <= tvy0s;
+                            line_a_x1 <= tvx1s;
+                            line_a_y1 <= tvy0s;
+                            // `debug_er($display("  0: (%d,%d) -> (%d,%d)", tvx0s, tvy0s, tvx1s, tvy0s));
+                        end
+                        'd1: begin
+                            state_return <= RECT_INIT;  // return for third edge
+                            line_a_x0 <= tvx0s;
+                            line_a_y0 <= tvy1s;
+                            line_a_x1 <= tvx1s;
+                            line_a_y1 <= tvy1s;
+                            // `debug_er($display("  1: (%d,%d) -> (%d,%d)", tvx0s, tvy1s, tvx1s, tvy1s));
+                        end
+                        'd2: begin
+                            state_return <= RECT_INIT;  // return for fourth edge
+                            line_a_x0 <= tvx0s;
+                            line_a_y0 <= tvy0s;
+                            line_a_x1 <= tvx0s;
+                            line_a_y1 <= tvy1s;
+                            // `debug_er($display("  2: (%d,%d) -> (%d,%d)", tvx0s, tvy0s, tvx0s, tvy1s));
+                        end
+                        default: begin
+                            state_return <= DECODE;  // decode next instruction after draw
+                            line_a_x0 <= tvx1s;
+                            line_a_y0 <= tvy0s;
+                            line_a_x1 <= tvx1s;
+                            line_a_y1 <= tvy1s;
+                            // `debug_er($display("  3: (%d,%d) -> (%d,%d)", tvx1s, tvy0s, tvx1s, tvy1s));
+                        end
+                    endcase
+                end
+                RECT_EXEC: begin
+                    if (line_a_done_latch) state <= state_return;
+                    line_a_start <= 0;
+                    drawing <= line_a_valid;
+                    x <= line_a_x;
+                    y <= line_a_y;
+                end
+                RECTF_INIT: begin
+                    cnt_fill <= cnt_fill + 1;
+                    state <= RECTF_EXEC;
+                    state_return <= (tvy0s + cnt_fill < tvy1s) ? RECTF_INIT : DECODE;
+                    fline_start <= 1;
+                    fline_y  <= tvy0s + cnt_fill;
+                    fline_x0 <= tvx0s;
+                    fline_x1 <= tvx1s;
+                end
+                RECTF_EXEC: begin
+                    if (fline_done_latch) state <= state_return;
+                    fline_start <= 0;
+                    drawing <= fline_valid;
+                    x <= fline_x;
+                    y <= fline_y;
+                end
+                TRI_INIT_B0: begin  // A: tv0s -> tv2s; B0: tv0s -> tv1s
+                    state <= TRI_WAIT;
+                    // `debug_er($display("  sorted (%d,%d) (%d,%d) (%d,%d)", tvx0s, tvy0s, tvx1s, tvy1s, tvx2s, tvy2s));
+                    tri_b_left <= (sext(tvx1s) - sext(tvx0s))*(sext(tvy2s) - sext(tvy0s)) <  // sign extend for cross product
+                                (sext(tvy1s) - sext(tvy0s))*(sext(tvx2s) - sext(tvx0s));
+                    // line A
+                    line_a_x0 <= tvx0s;
+                    line_a_y0 <= tvy0s;
+                    line_a_x1 <= tvx2s;
+                    line_a_y1 <= tvy2s;
+                    tri_a_xdec <= (tvx0s > tvx2s);  // does x decrease as we draw A?
+                    line_a_start <= 1;
+                    // line B0
+                    line_b_x0 <= tvx0s;
+                    line_b_y0 <= tvy0s;
+                    line_b_x1 <= tvx1s;
+                    line_b_y1 <= tvy1s;
+                    tri_b_edge <= 0;
+                    tri_b_xdec <= (tvx0s > tvx1s);  // does x decrease as we draw B0?
+                    tri_b1_skip <= 0;  // no skip on B0
+                    line_b_start <= 1;
+                end
+                TRI_INIT_B1: begin  // B1: tv1s -> tv2s
+                    state <= TRI_WAIT;
+                    line_b_x0 <= tvx1s;
+                    line_b_y0 <= tvy1s;
+                    line_b_x1 <= tvx2s;
+                    line_b_y1 <= tvy2s;
+                    tri_b_edge <= 1;
+                    tri_b_xdec <= (tvx1s > tvx2s);  // does x decrease as we draw?
+                    tri_b1_skip <= 1;  // skip for y for B1 (handled by end of B0)
+                    line_b_start <= 1;
+                end
+                TRI_WAIT: begin
+                    // `debug_er($display("  tri_b_left=%b", tri_b_left));
+                    if (tri_b1_skip) begin  // B line repeats at start of B1: jump ahead one line
+                        state <= TRI_LINE_B;
+                        line_b_oe <= 1;
+                    end else begin
+                        state <= TRI_LINE_A;
+                        line_a_oe <= 1;
+                    end
+                    line_a_start <= 0;  // clear start signals
+                    line_b_start <= 0;
+                end
+                TRI_LINE_A: begin
+                    if (line_a_valid) begin
+                        drawing <= 1;
+                        x <= line_a_x;
+                        y <= line_a_y;
+                        // `debug_er($display("  line A  - draw (%d,%d)", line_a_x, line_a_y));
+                    end
+                    if (line_a_fill || (!line_a_busy)) begin
+                        state <= TRI_LINE_B;
+                        if (!tri_b_left) fline_x0 <= tri_a_xdec ? line_a_lx + 1 : line_a_x + 1;
+                        else fline_x1 <= tri_a_xdec ? line_a_x - 1 : line_a_lx - 1;
+                        line_a_oe <= 0;
+                        line_b_oe <= 1;
+                    end
+                end
+                TRI_LINE_B: begin
+                    if (line_b_valid) begin
+                        drawing <= 1;
+                        x <= line_b_x;
+                        y <= line_b_y;
+                        // `debug_er($display("  line B%b - draw (%d,%d)", tri_b_edge, line_b_x, line_b_y));
+                    end
+                    if (line_b_fill || (!line_b_busy)) begin
+                        state <= TRI_FILL_INIT;
+                        if (tri_b_left) fline_x0 <= tri_b_xdec ? line_b_lx + 1 : line_b_x + 1;
+                        else fline_x1 <= tri_b_xdec ? line_b_x - 1 : line_b_lx - 1;
+                        fline_y <= line_b_y;
+                        line_b_oe <= 0;
+                    end
+                end
+                TRI_FILL_INIT: begin
+                    if (imm8[OPT_FILL] == 0 || (line_a_busy | line_b_busy) == 0) begin  // skip if unfilled or both lines are done
+                        state <= TRI_NEXT_Y;
+                    end else if (tri_b1_skip == 1) begin
+                        state <= TRI_NEXT_Y;
+                        tri_b1_skip <= 0;
+                        // `debug_er($display("  line B1 ** skip fill on first y ** - a_y=%d, b_y=%d", line_a_y, line_b_y));
+                    end else if (fline_x0 <= fline_x1) begin  // do we have a line to draw? Depends indirectly on dot product.
+                        state <= TRI_FILL_EXEC;
+                        fline_start <= 1;
+                        // `debug_er($display("  fline   - draw (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
+                    end else begin
+                        state <= TRI_NEXT_Y;
+                        // `debug_er($display("  fline   - no   (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
+                    end
+                end
+                TRI_FILL_EXEC: begin
+                    if (fline_done_latch) state <= TRI_NEXT_Y;
+                    else if (fline_valid) begin
+                        drawing <= 1;
+                        x <= fline_x;
+                        y <= fline_y;
+                    end
+                    fline_start <= 0;
+                end
+                TRI_NEXT_Y: begin
+                    if (!line_b_busy) state <= (tri_b_edge == 0) ? TRI_INIT_B1 : DECODE;
+                    else begin
+                        state <= TRI_LINE_A;
+                        line_a_oe <= 1;
+                    end
+                    // `debug_er($display("  -- next tri line --"));
+                end
+                DONE: begin
+                    state <= IDLE;
+                    busy <= 0;
+                    pc_reg <= 0;  // reset pc: execution always starts from address 0
+                    pc_debug <= 0;
+                    `debug_er($display("** DONE **"));
+                end
+                default: begin // IDLE
+                    busy <= 0;
+                    if (start_pending) begin
+                        state <= FETCH;
+                        instr_invalid <= 0;
+                        busy <= 1;
+                    end
+                end
+            endcase
         end
     end
 
@@ -613,7 +638,7 @@ module earthrise #(
         .clk(clk),
         .rst(rst),
         .start(line_a_start),
-        .oe(line_a_oe),
+        .oe(line_a_oe && en),
         .x0(line_a_x0),
         .y0(line_a_y0),
         .x1(line_a_x1),
@@ -631,7 +656,7 @@ module earthrise #(
         .clk(clk),
         .rst(rst),
         .start(line_b_start),
-        .oe(line_b_oe),
+        .oe(line_b_oe && en),
         .x0(line_b_x0),
         .y0(line_b_y0),
         .x1(line_b_x1),
@@ -651,7 +676,7 @@ module earthrise #(
         .clk(clk),
         .rst(rst),
         .start(fline_start),
-        .oe(1'b1),
+        .oe(en),
         .x0(fline_x0),
         .x1(fline_x1),
         .x(fline_x),
@@ -666,7 +691,7 @@ module earthrise #(
         .clk(clk),
         .rst(rst),
         .start(circle_start),
-        .oe(circle_oe),
+        .oe(circle_oe && en),
         .r0(circle_r0),
         .xa(circle_xa),
         .ya(circle_ya),
@@ -689,6 +714,7 @@ module earthrise #(
         .SHIFTW(CANV_SHIFTW)
     ) canv_draw_agu_inst (
         .clk(clk),
+        .en(en),
         .w(canv_w),
         .h(canv_h),
         .x({{4{x[ICORDW-1]}}, x}),  // widen 12-bit integers (sign extension)
@@ -704,16 +730,18 @@ module earthrise #(
     localparam ADDR_LAT = 3;
     reg [ADDR_LAT-1:0] vram_we_sr;
     always @(posedge clk) begin
-        vram_we_sr <= {drawing, vram_we_sr[ADDR_LAT-1:1]};
         if (rst) vram_we_sr <= 0;
+        else if (en) vram_we_sr <= {drawing, vram_we_sr[ADDR_LAT-1:1]};
     end
 
     // delay colour to match address calculation
     reg [COLRW-1:0] colr_p1, colr_p2, colr_p3;
     always @(posedge clk) begin
-        colr_p1 <= colr;
-        colr_p2 <= colr_p1;
-        colr_p3 <= colr_p2;
+        if (en) begin
+            colr_p1 <= colr;
+            colr_p2 <= colr_p1;
+            colr_p3 <= colr_p2;
+        end
     end
 
     // vram write mask - use latency-corrected write-enable and colour

--- a/hardware/gfx/earthrise.v
+++ b/hardware/gfx/earthrise.v
@@ -31,7 +31,7 @@ module earthrise #(
     output reg  [WORD-1:0] vram_din,           // vram data in
     output reg  [WORD-1:0] vram_wmask,         // vram write mask
     output reg  busy,                          // execution in progress
-    output reg  done,                          // commands complete (high for one tick)
+    output wire done,                          // commands complete (high for one tick)
     output reg  instr_invalid                  // invalid instruction
     );
 
@@ -100,29 +100,29 @@ module earthrise #(
     reg signed [ICORDW-1:0] tvx2s, tvy2s;
 
     // line A signals
-    reg line_a_start, line_a_oe;
-    wire line_a_busy, line_a_valid, line_a_fill, line_a_done;
+    reg line_a_start;
+    wire line_a_oe, line_a_busy, line_a_valid, line_a_fill;
     reg signed [ICORDW-1:0] line_a_x0, line_a_y0;
     reg signed [ICORDW-1:0] line_a_x1, line_a_y1;
     wire signed [ICORDW-1:0] line_a_x, line_a_y, line_a_lx;
 
     // line B signals
-    reg line_b_start, line_b_oe;
-    wire line_b_busy, line_b_valid, line_b_fill;
+    reg line_b_start;
+    wire line_b_oe, line_b_busy, line_b_valid, line_b_fill;
     reg signed [ICORDW-1:0] line_b_x0, line_b_y0;
     reg signed [ICORDW-1:0] line_b_x1, line_b_y1;
     wire signed [ICORDW-1:0] line_b_x, line_b_y, line_b_lx;
 
     // fast line signals
-    wire fline_valid, fline_done;
     reg fline_start;
+    wire fline_valid, fline_busy;
     reg signed [ICORDW-1:0] fline_x0, fline_x1;
     wire signed [ICORDW-1:0] fline_x;
     reg signed [ICORDW-1:0] fline_y;
 
     // circle signals
-    reg circle_start, circle_oe;
-    wire circle_valid, circle_busy;
+    reg circle_start;
+    wire circle_oe, circle_valid, circle_busy;
     reg signed [ICORDW-1:0] circle_x0, circle_y0;
     reg signed [ICORDW-1:0] circle_r0;
     wire signed [ICORDW-1:0] circle_xa, circle_ya;
@@ -175,26 +175,12 @@ module earthrise #(
     // select instruction from command list data (upper or lower half from word)
     wire [INSTRW-1:0] instr = pc[1] ? cmd_list[2*INSTRW-1:INSTRW] : cmd_list[INSTRW-1:0];
 
-    // latch start and done signals so we can act on them later if !en
+    // latch start signal so we can act on it later if Earthrise is disabled
     reg start_pending;
     always @(posedge clk) begin
         if (rst) start_pending <= 0;
         else if (start) start_pending <= 1;
         else if (state == IDLE && en) start_pending <= 0;
-    end
-
-    reg line_a_done_latch;
-    always @(posedge clk) begin
-        if (rst) line_a_done_latch <= 0;
-        else if (line_a_done) line_a_done_latch <= 1;
-        else if (en) line_a_done_latch <= 0;
-    end
-
-    reg fline_done_latch;
-    always @(posedge clk) begin
-        if (rst) fline_done_latch <= 0;
-        else if (fline_done) fline_done_latch <= 1;
-        else if (en) fline_done_latch <= 0;
     end
 
     always @(posedge clk) begin
@@ -300,11 +286,7 @@ module earthrise #(
                         'hD: begin
                             // handle colour once for all shapes; fill colours work for shapes without filled forms
                             colr <= imm8[OPT_FILL] ? (imm8[OPT_COLR] ? fcb : fca)
-                                                : (imm8[OPT_COLR] ? lcb : lca);
-
-                            // disable line output by default
-                            line_a_oe <= 0;
-                            line_b_oe <= 0;
+                                                   : (imm8[OPT_COLR] ? lcb : lca);
 
                             // select drawing function
                             case (fun)
@@ -324,7 +306,6 @@ module earthrise #(
                                         `debug_er($display("0x%x: fline    (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
                                     end else begin
                                         state <= LINE_EXEC;
-                                        line_a_oe <= 1;
                                         line_a_start <= 1;   // use line instance A
                                         line_a_x0 <= tvx0;
                                         line_a_y0 <= tvy0;
@@ -380,15 +361,14 @@ module earthrise #(
                     endcase
                 end
                 LINE_EXEC: begin
-                    if (line_a_done_latch) state <= DECODE;
+                    if (!line_a_busy) state <= DECODE;
                     line_a_start <= 0;
                     drawing <= line_a_valid;
                     x <= line_a_x;
                     y <= line_a_y;
                 end
                 CIRCLE_CALC: begin
-                    if (circle_valid) begin
-                        // register the result because circle calc keeps going due to oe implementation
+                    if (circle_valid) begin  // register the result before leaving CIRCLE_CALC
                         circle_x_offs <= circle_xa;
                         circle_y_offs <= circle_ya;
                         state <= (imm8[OPT_FILL] == 0) ? CIRCLE_PIX : CIRCLE_FILL_DI;
@@ -396,7 +376,7 @@ module earthrise #(
                     circle_start <= 0;
                 end
                 CIRCLE_PIX: begin
-                    if (cnt_draw == 3) state <= (circle_busy) ? CIRCLE_CALC : DECODE;
+                    if (cnt_draw == 3) state <= circle_busy ? CIRCLE_CALC : DECODE;
                     drawing <= 1;
                     cnt_draw <= cnt_draw + 1;
                     case (cnt_draw)
@@ -414,7 +394,7 @@ module earthrise #(
                     fline_x1 <= circle_x0 - circle_x_offs;
                 end
                 CIRCLE_FILL_DD: begin
-                    if (fline_done_latch) state <= CIRCLE_FILL_UI;
+                    if (!fline_busy) state <= CIRCLE_FILL_UI;
                     fline_start <= 0;
                     drawing <= fline_valid;
                     x <= fline_x;
@@ -426,14 +406,14 @@ module earthrise #(
                     fline_y  <= circle_y0 - circle_y_offs;
                 end
                 CIRCLE_FILL_UD: begin  // almost duplicate of CIRCLE_FILL_DD - could we use return state?
-                    if (fline_done_latch) state <= (circle_busy) ? CIRCLE_CALC : DECODE;
+                    if (!fline_busy) state <= circle_busy ? CIRCLE_CALC : DECODE;
                     fline_start <= 0;
                     drawing <= fline_valid;
                     x <= fline_x;
                     y <= fline_y;
                 end
                 FLINE_EXEC: begin
-                    if (fline_done_latch) state <= DECODE;
+                    if (!fline_busy) state <= DECODE;
                     fline_start <= 0;
                     drawing <= fline_valid;
                     x <= fline_x;
@@ -441,7 +421,6 @@ module earthrise #(
                 end
                 RECT_INIT: begin
                     state <= RECT_EXEC;
-                    line_a_oe <= 1;
                     line_a_start <= 1;
                     cnt_draw <= cnt_draw + 1;
                     case (cnt_draw)
@@ -480,7 +459,7 @@ module earthrise #(
                     endcase
                 end
                 RECT_EXEC: begin
-                    if (line_a_done_latch) state <= state_return;
+                    if (!line_a_busy) state <= state_return;
                     line_a_start <= 0;
                     drawing <= line_a_valid;
                     x <= line_a_x;
@@ -496,7 +475,7 @@ module earthrise #(
                     fline_x1 <= tvx1s;
                 end
                 RECTF_EXEC: begin
-                    if (fline_done_latch) state <= state_return;
+                    if (!fline_busy) state <= state_return;
                     fline_start <= 0;
                     drawing <= fline_valid;
                     x <= fline_x;
@@ -537,13 +516,7 @@ module earthrise #(
                 end
                 TRI_WAIT: begin
                     // `debug_er($display("  tri_b_left=%b", tri_b_left));
-                    if (tri_b1_skip) begin  // B line repeats at start of B1: jump ahead one line
-                        state <= TRI_LINE_B;
-                        line_b_oe <= 1;
-                    end else begin
-                        state <= TRI_LINE_A;
-                        line_a_oe <= 1;
-                    end
+                    state <= tri_b1_skip ? TRI_LINE_B : TRI_LINE_A;  // B line repeats at start of B1: jump ahead one line
                     line_a_start <= 0;  // clear start signals
                     line_b_start <= 0;
                 end
@@ -558,8 +531,6 @@ module earthrise #(
                         state <= TRI_LINE_B;
                         if (!tri_b_left) fline_x0 <= tri_a_xdec ? line_a_lx + 1 : line_a_x + 1;
                         else fline_x1 <= tri_a_xdec ? line_a_x - 1 : line_a_lx - 1;
-                        line_a_oe <= 0;
-                        line_b_oe <= 1;
                     end
                 end
                 TRI_LINE_B: begin
@@ -574,7 +545,6 @@ module earthrise #(
                         if (tri_b_left) fline_x0 <= tri_b_xdec ? line_b_lx + 1 : line_b_x + 1;
                         else fline_x1 <= tri_b_xdec ? line_b_x - 1 : line_b_lx - 1;
                         fline_y <= line_b_y;
-                        line_b_oe <= 0;
                     end
                 end
                 TRI_FILL_INIT: begin
@@ -594,7 +564,7 @@ module earthrise #(
                     end
                 end
                 TRI_FILL_EXEC: begin
-                    if (fline_done_latch) state <= TRI_NEXT_Y;
+                    if (!fline_busy) state <= TRI_NEXT_Y;
                     else if (fline_valid) begin
                         drawing <= 1;
                         x <= fline_x;
@@ -603,11 +573,8 @@ module earthrise #(
                     fline_start <= 0;
                 end
                 TRI_NEXT_Y: begin
-                    if (!line_b_busy) state <= (tri_b_edge == 0) ? TRI_INIT_B1 : DECODE;
-                    else begin
-                        state <= TRI_LINE_A;
-                        line_a_oe <= 1;
-                    end
+                    if (!line_b_busy) state <= tri_b_edge ? DECODE : TRI_INIT_B1;
+                    else state <= TRI_LINE_A;
                     // `debug_er($display("  -- next tri line --"));
                 end
                 DONE: begin
@@ -629,10 +596,11 @@ module earthrise #(
         end
     end
 
-    always @(*) done = (state == DONE);
+    assign done = (state == DONE);
 
-    // circle output enable (consider using registered signal in FSM like other OE)
-    always @(*) circle_oe = (state == CIRCLE_CALC);
+    assign line_a_oe = (state == LINE_EXEC || state == RECT_EXEC || state == TRI_LINE_A);
+    assign line_b_oe = (state == TRI_LINE_B);
+    assign circle_oe = (state == CIRCLE_CALC);
 
     line #(.CORDW(ICORDW)) line_a_inst (
         .clk(clk),
@@ -646,10 +614,9 @@ module earthrise #(
         .x(line_a_x),
         .y(line_a_y),
         .lx(line_a_lx),
-        .busy(line_a_busy),
-        .valid(line_a_valid),
         .fill(line_a_fill),
-        .done(line_a_done)
+        .busy(line_a_busy),
+        .valid(line_a_valid)
     );
 
     line #(.CORDW(ICORDW)) line_b_inst (
@@ -664,12 +631,9 @@ module earthrise #(
         .x(line_b_x),
         .y(line_b_y),
         .lx(line_b_lx),
-        .busy(line_b_busy),
-        .valid(line_b_valid),
         .fill(line_b_fill),
-        /* verilator lint_off PINCONNECTEMPTY */
-        .done()  // not needed
-        /* verilator lint_on PINCONNECTEMPTY */
+        .busy(line_b_busy),
+        .valid(line_b_valid)
     );
 
     fline #(.CORDW(ICORDW)) fline_inst (
@@ -680,11 +644,8 @@ module earthrise #(
         .x0(fline_x0),
         .x1(fline_x1),
         .x(fline_x),
-        /* verilator lint_off PINCONNECTEMPTY */
-        .busy(),
-        /* verilator lint_on PINCONNECTEMPTY */
-        .valid(fline_valid),
-        .done(fline_done)
+        .busy(fline_busy),
+        .valid(fline_valid)
     );
 
     circle #(.CORDW(ICORDW)) circle_inst (
@@ -696,10 +657,7 @@ module earthrise #(
         .xa(circle_xa),
         .ya(circle_ya),
         .busy(circle_busy),
-        .valid(circle_valid),
-        /* verilator lint_off PINCONNECTEMPTY */
-        .done()
-        /* verilator lint_on PINCONNECTEMPTY */
+        .valid(circle_valid)
     );
 
 

--- a/hardware/gfx/earthrise.v
+++ b/hardware/gfx/earthrise.v
@@ -32,6 +32,7 @@ module earthrise #(
     output reg  [WORD-1:0] vram_wmask,         // vram write mask
     output reg  busy,                          // execution in progress
     output wire done,                          // commands complete (high for one tick)
+    output reg  [WORD-1:0] cycle_cnt,          // number of clock cycles to execute command list
     output reg  instr_invalid                  // invalid instruction
     );
 
@@ -182,6 +183,7 @@ module earthrise #(
             pc_start <= 0;
             drawing <= 0;
             busy <= 0;
+            cycle_cnt <= 0;
             instr_invalid <= 0;
             line_a_start <= 0;
             line_b_start <= 0;
@@ -213,7 +215,6 @@ module earthrise #(
                         imm8 <= instr[IMM8-1:0];
                         cnt_draw <= 0;  // draw counter
                         cnt_fill <= 0;  // fill counter
-                        // `debug_er($display(">> decode  %x - instr: %x", pc, instr));
                     end
                 end
                 EXEC: begin
@@ -238,38 +239,21 @@ module earthrise #(
                         end
                         'hC: begin  // colour and control
                             case (fun)
-                                'h0: begin
-                                    lca <= imm8;
-                                    `debug_er($display("0x%x: lca      %x", pc_debug, imm8));
-                                end
-                                'h1: begin
-                                    lcb <= imm8;
-                                    `debug_er($display("0x%x: lcb      %x", pc_debug, imm8));
-                                end
-                                'h2: begin
-                                    fca <= imm8;
-                                    `debug_er($display("0x%x: fca      %x", pc_debug, imm8));
-                                end
-                                'h3: begin
-                                    fcb <= imm8;
-                                    `debug_er($display("0x%x: fcb      %x", pc_debug, imm8));
-                                end
+                                'h0: lca <= imm8;
+                                'h1: lcb <= imm8;
+                                'h2: fca <= imm8;
+                                'h3: fcb <= imm8;
                                 'hA: begin  // 0xCA - Jump (Change Address)
                                     state <= JUMP_WAIT;  // wait a cycle after changing PC
                                     pc_reg <= {1'b0, pc_start};
-                                    `debug_er($display("0x%x: jump     %x", pc_debug, pc_start));
+                                    `debug_er($display("%d - 0x%x: jump     %x", cycle_cnt, pc_debug, pc_start));
                                 end
-                                'hC: begin  // 0xCC - NOP (Continue)
-                                    state <= FETCH;
-                                end
-                                'hE: begin  // 0xCE Stop (CEase)
-                                    state <= DONE;
-                                    `debug_er($display("0x%x: stop", pc_debug));  // use pc_debug because pc points at NEXT instruction
-                                end
-                                default: begin
+                                'hC: state <= FETCH;  // 0xCC - NOP (Continue)
+                                'hE: state <= DONE;   // 0xCE Stop (CEase)
+                                default: begin  // invalid instruction
                                     state <= DONE;
                                     instr_invalid <= 1;
-                                    `debug_er($display("0x%x: Invalid Instruction - no such instruction '0xC%x'.", pc_debug, fun));
+                                    `debug_er($display("%d - 0x%x: Invalid Instruction - no such instruction '0xC%x'.", cycle_cnt, pc_debug, fun));
                                 end
                             endcase
                         end
@@ -284,7 +268,7 @@ module earthrise #(
                                     x <= tvx0;
                                     y <= tvy0;
                                     drawing <= 1;
-                                    `debug_er($display("0x%x: pixel    (%d,%d)", pc_debug, tvx0, tvy0));
+                                    `debug_er($display("%d - 0x%x: pixel    (%d,%d)", cycle_cnt, pc_debug, tvx0, tvy0));
                                 end
                                 'h1: begin  // draw line
                                     if (tvy0 == tvy1) begin  // fast line
@@ -294,7 +278,7 @@ module earthrise #(
                                         fline_x0 <= tvx0;
                                         fline_x1 <= tvx1;
                                         fline_y <= tvy0;  // use tvy0 for vertical position
-                                        `debug_er($display("0x%x: fline    (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
+                                        `debug_er($display("%d - 0x%x: fline    (%d,%d)->(%d,%d)", cycle_cnt, pc_debug, tvx0, tvy0, tvx1, tvy1));
                                     end else begin
                                         state <= LINE_EXEC;
                                         line_a_start <= 1;   // use line instance A
@@ -302,7 +286,7 @@ module earthrise #(
                                         line_a_y0 <= tvy0;
                                         line_a_x1 <= tvx1;
                                         line_a_y1 <= tvy1;
-                                        `debug_er($display("0x%x: line     (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
+                                        `debug_er($display("%d - 0x%x: line     (%d,%d)->(%d,%d)", cycle_cnt, pc_debug, tvx0, tvy0, tvx1, tvy1));
                                     end
                                 end
                                 'h2: begin  // draw circle
@@ -313,13 +297,13 @@ module earthrise #(
                                         circle_y0 <= tvy0;
                                         circle_r0 <= r0;
                                     end else state <= FETCH;
-                                    `debug_er($display("0x%x: circle   (%d,%d) r=%d", pc_debug, tvx0, tvy0, r0));
+                                    `debug_er($display("%d - 0x%x: circle   (%d,%d) r=%d", cycle_cnt, pc_debug, tvx0, tvy0, r0));
                                 end
                                 'h3: begin  // draw triangle (sort vertices first)
                                     if (tri_min == tri_max || tri_degen_x) begin  // degenerate triangle
                                         state <= DONE;
                                         instr_invalid <= 1;
-                                        `debug_er($display("0x%x: Invalid Instruction - degenerate triangle.", pc_debug));
+                                        `debug_er($display("%d - 0x%x: Invalid Instruction - degenerate triangle.", cycle_cnt, pc_debug));
                                     end else state <= TRI_INIT_B0;
                                     tvx0s <= (tri_min == 0) ? tvx0 : (tri_min == 1) ? tvx1 : tvx2;
                                     tvy0s <= (tri_min == 0) ? tvy0 : (tri_min == 1) ? tvy1 : tvy2;
@@ -327,7 +311,7 @@ module earthrise #(
                                     tvy1s <= (tri_mid == 0) ? tvy0 : (tri_mid == 1) ? tvy1 : tvy2;
                                     tvx2s <= (tri_max == 0) ? tvx0 : (tri_max == 1) ? tvx1 : tvx2;
                                     tvy2s <= (tri_max == 0) ? tvy0 : (tri_max == 1) ? tvy1 : tvy2;
-                                    `debug_er($display("0x%x: triangle (%d,%d) (%d,%d) (%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1, tvx2, tvy2));
+                                    `debug_er($display("%d - 0x%x: triangle (%d,%d) (%d,%d) (%d,%d)", cycle_cnt, pc_debug, tvx0, tvy0, tvx1, tvy1, tvx2, tvy2));
                                 end
                                 'h4: begin  // draw rect (sort vertices first)
                                     tvx0s <= (tvx0 < tvx1) ? tvx0 : tvx1;
@@ -335,19 +319,19 @@ module earthrise #(
                                     tvx1s <= (tvx0 < tvx1) ? tvx1 : tvx0;
                                     tvy1s <= (tvy0 < tvy1) ? tvy1 : tvy0;
                                     state <= (imm8[OPT_FILL] == 0) ? RECT_INIT : RECTF_INIT;
-                                    `debug_er($display("0x%x: rect     (%d,%d)->(%d,%d)", pc_debug, tvx0, tvy0, tvx1, tvy1));
+                                    `debug_er($display("%d - 0x%x: rect     (%d,%d)->(%d,%d)", cycle_cnt, pc_debug, tvx0, tvy0, tvx1, tvy1));
                                 end
                                 default: begin
                                     state <= DONE;
                                     instr_invalid <= 1;
-                                    `debug_er($display("0x%x: Invalid Instruction - no such draw function '%x'.", pc_debug, fun));
+                                    `debug_er($display("%d - 0x%x: Invalid Instruction - no such draw function '%x'.", cycle_cnt, pc_debug, fun));
                                 end
                             endcase
                         end
                         default: begin
                             state <= DONE;
                             instr_invalid <= 1;
-                            `debug_er($display("0x%x: Invalid Instruction - no such opcode '%x'.", pc_debug, opc));
+                            `debug_er($display("%d - 0x%x: Invalid Instruction - no such opcode '%x'.", cycle_cnt, pc_debug, opc));
                         end
                     endcase
                 end
@@ -409,7 +393,6 @@ module earthrise #(
                             line_a_y0 <= tvy0s;
                             line_a_x1 <= tvx1s;
                             line_a_y1 <= tvy0s;
-                            // `debug_er($display("  0: (%d,%d) -> (%d,%d)", tvx0s, tvy0s, tvx1s, tvy0s));
                         end
                         'd1: begin
                             state_return <= RECT_INIT;  // return for third edge
@@ -417,7 +400,6 @@ module earthrise #(
                             line_a_y0 <= tvy1s;
                             line_a_x1 <= tvx1s;
                             line_a_y1 <= tvy1s;
-                            // `debug_er($display("  1: (%d,%d) -> (%d,%d)", tvx0s, tvy1s, tvx1s, tvy1s));
                         end
                         'd2: begin
                             state_return <= RECT_INIT;  // return for fourth edge
@@ -425,7 +407,6 @@ module earthrise #(
                             line_a_y0 <= tvy0s;
                             line_a_x1 <= tvx0s;
                             line_a_y1 <= tvy1s;
-                            // `debug_er($display("  2: (%d,%d) -> (%d,%d)", tvx0s, tvy0s, tvx0s, tvy1s));
                         end
                         default: begin
                             state_return <= DECODE;  // decode next instruction after draw
@@ -433,7 +414,6 @@ module earthrise #(
                             line_a_y0 <= tvy0s;
                             line_a_x1 <= tvx1s;
                             line_a_y1 <= tvy1s;
-                            // `debug_er($display("  3: (%d,%d) -> (%d,%d)", tvx1s, tvy0s, tvx1s, tvy1s));
                         end
                     endcase
                 end
@@ -455,7 +435,6 @@ module earthrise #(
                 end
                 TRI_INIT_B0: begin  // A: tv0s -> tv2s; B0: tv0s -> tv1s
                     state <= TRI_WAIT;
-                    // `debug_er($display("  sorted (%d,%d) (%d,%d) (%d,%d)", tvx0s, tvy0s, tvx1s, tvy1s, tvx2s, tvy2s));
                     // line A
                     line_a_x0 <= tvx0s;
                     line_a_y0 <= tvy0s;
@@ -494,7 +473,6 @@ module earthrise #(
                         drawing <= 1;
                         x <= line_a_x;
                         y <= line_a_y;
-                        // `debug_er($display("  line A  - draw (%d,%d)", line_a_x, line_a_y));
                     end
                     if (line_a_fill || (!line_a_busy)) begin
                         state <= TRI_LINE_B;
@@ -507,7 +485,6 @@ module earthrise #(
                         drawing <= 1;
                         x <= line_b_x;
                         y <= line_b_y;
-                        // `debug_er($display("  line B%b - draw (%d,%d)", tri_b_edge, line_b_x, line_b_y));
                     end
                     if (line_b_fill || (!line_b_busy)) begin
                         state <= TRI_FILL_INIT;
@@ -528,28 +505,22 @@ module earthrise #(
                     end else if (tri_b1_skip == 1) begin
                         state <= TRI_NEXT_Y;
                         tri_b1_skip <= 0;
-                        // `debug_er($display("  line B1 ** skip fill on first y ** - a_y=%d, b_y=%d", line_a_y, line_b_y));
                     end else if (fline_x0 <= fline_x1) begin  // do we have a filled line to draw?
                         state <= FLINE_EXEC;
                         state_return <= TRI_NEXT_Y;
                         fline_start <= 1;
-                        // `debug_er($display("  fline   - draw (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
-                    end else begin
-                        state <= TRI_NEXT_Y;
-                        // `debug_er($display("  fline   - no   (%d->%d) y=%d", fline_x0, fline_x1, fline_y));
-                    end
+                    end else state <= TRI_NEXT_Y;
                 end
                 TRI_NEXT_Y: begin
                     if (!line_b_busy) state <= tri_b_edge ? DECODE : TRI_INIT_B1;
                     else state <= TRI_LINE_A;
-                    // `debug_er($display("  -- next tri line --"));
                 end
                 DONE: begin
                     state <= IDLE;
                     busy <= 0;
                     pc_reg <= 0;  // reset pc: execution always starts from address 0
                     pc_debug <= 0;
-                    `debug_er($display("** DONE **"));
+                    `debug_er($display("** DONE ** %d cycles", cycle_cnt));
                 end
                 default: begin // IDLE
                     busy <= 0;
@@ -557,10 +528,12 @@ module earthrise #(
                         state <= FETCH;
                         instr_invalid <= 0;
                         busy <= 1;
+                        cycle_cnt <= 1;  // cycle counter starts
                     end
                 end
             endcase
         end
+        if (busy && state != DONE) cycle_cnt <= cycle_cnt + 1;
     end
 
     assign done = (state == DONE);

--- a/hardware/gfx/fline.v
+++ b/hardware/gfx/fline.v
@@ -15,9 +15,8 @@ module fline #(parameter CORDW=16) (  // signed coordinate width
     input  wire signed [CORDW-1:0] x0,  // point 0
     input  wire signed [CORDW-1:0] x1,  // point 1
     output reg  signed [CORDW-1:0] x,   // line position
-    output reg  busy,   // calculation request in progress
-    output reg  valid,  // output coordinates valid
-    output reg  done    // calculation complete (high for one tick)
+    output wire busy,  // calculation in progress
+    output wire valid  // output coordinates valid
     );
 
     // draw state machine
@@ -27,38 +26,28 @@ module fline #(parameter CORDW=16) (  // signed coordinate width
     localparam STATEW = 1;  // state width (bits)
     reg [STATEW-1:0] state;
 
-    always @(*) valid = (state == DRAW && oe);
-
     reg signed [CORDW-1:0] x_end;  // hold end coordinate
 
     always @(posedge clk) begin
         case (state)
             DRAW: begin
                 if (oe) begin
-                    if (x == x_end) begin
-                        state <= IDLE;
-                        busy <= 0;
-                        done <= 1;
-                    end else begin
-                        x <= x + 1;
-                    end
+                    if (x == x_end) state <= IDLE;
+                    else x <= x + 1;
                 end
             end
             default: begin  // IDLE
-                done <= 0;
                 if (start) begin
                     state <= DRAW;
-                    busy <= 1;
                     x     <= (x1 >= x0) ? x0 : x1;
                     x_end <= (x1 >= x0) ? x1 : x0;
                 end
             end
         endcase
 
-        if (rst) begin
-            state <= IDLE;
-            busy <= 0;
-            done <= 0;
-        end
+        if (rst) state <= IDLE;
     end
+
+    assign busy  = (state != IDLE) || start;
+    assign valid = (state == DRAW && oe);
 endmodule

--- a/hardware/gfx/line.v
+++ b/hardware/gfx/line.v
@@ -13,7 +13,7 @@ module line #(parameter CORDW=16) (  // signed coordinate width
     input  wire signed [CORDW-1:0] x0, y0,  // point 0
     input  wire signed [CORDW-1:0] x1, y1,  // point 1
     output reg  signed [CORDW-1:0] x,  y,   // line position
-    output reg  signed [CORDW-1:0] lx,      // first x-coordinate for this y
+    output reg  signed [CORDW-1:0] xs,      // start x-coordinate for this y
     output wire fill,  // ready for fill
     output wire busy,  // calculation in progress
     output wire valid  // output coordinates valid
@@ -61,7 +61,7 @@ module line #(parameter CORDW=16) (  // signed coordinate width
                     else begin
                         if (movx && movy) begin
                             x <= right ? x + 1 : x - 1;
-                            lx <= right ? x + 1 : x - 1;
+                            xs <= right ? x + 1 : x - 1;
                             y <= y + 1;
                             err <= err + dy + dx;
                         end else if (movx) begin
@@ -84,7 +84,7 @@ module line #(parameter CORDW=16) (  // signed coordinate width
                 err <= dx + dy;
                 x <= xa;
                 y <= ya;
-                lx <= xa;
+                xs <= xa;
                 x_end <= xb;
                 y_end <= yb;
             end
@@ -94,7 +94,7 @@ module line #(parameter CORDW=16) (  // signed coordinate width
                     right <= (xa < xb);  // draw right to left?
                     x <= x0;  // init to start coords to avoid spurious pixels
                     y <= y0;
-                    lx <= x0;
+                    xs <= x0;
                 end
             end
         endcase

--- a/hardware/gfx/line.v
+++ b/hardware/gfx/line.v
@@ -14,10 +14,9 @@ module line #(parameter CORDW=16) (  // signed coordinate width
     input  wire signed [CORDW-1:0] x1, y1,  // point 1
     output reg  signed [CORDW-1:0] x,  y,   // line position
     output reg  signed [CORDW-1:0] lx,      // first x-coordinate for this y
-    output reg  busy,   // calculation in progress
-    output reg  valid,  // output coordinates valid
-    output reg  fill,   // ready for fill
-    output reg  done    // calculation complete (high for one tick)
+    output wire fill,  // ready for fill
+    output wire busy,  // calculation in progress
+    output wire valid  // output coordinates valid
     );
 
     // line properties
@@ -52,22 +51,14 @@ module line #(parameter CORDW=16) (  // signed coordinate width
     localparam STATEW = 2;  // state width (bits)
     reg [STATEW-1:0] state;
 
-    always @(*) valid  = (state == DRAW && oe);
-
     wire end_coord = (x == x_end && y == y_end);
-
-    // when to fill a line
-    always @(*) fill = (valid && (movy || end_coord));
 
     always @(posedge clk) begin
         case (state)
             DRAW: begin
                 if (oe) begin
-                    if (end_coord) begin
-                        state <= IDLE;
-                        busy <= 0;
-                        done <= 1;
-                    end else begin
+                    if (end_coord) state <= IDLE;
+                    else begin
                         if (movx && movy) begin
                             x <= right ? x + 1 : x - 1;
                             lx <= right ? x + 1 : x - 1;
@@ -98,11 +89,9 @@ module line #(parameter CORDW=16) (  // signed coordinate width
                 y_end <= yb;
             end
             default: begin  // IDLE
-                done <= 0;
                 if (start) begin
                     state <= INIT_0;
                     right <= (xa < xb);  // draw right to left?
-                    busy <= 1;
                     x <= x0;  // init to start coords to avoid spurious pixels
                     y <= y0;
                     lx <= x0;
@@ -110,10 +99,10 @@ module line #(parameter CORDW=16) (  // signed coordinate width
             end
         endcase
 
-        if (rst) begin
-            state <= IDLE;
-            busy <= 0;
-            done <= 0;
-        end
+        if (rst) state <= IDLE;
     end
+
+    assign fill  = (valid && (movy || end_coord));  // when to fill a line
+    assign busy  = (state != IDLE) || start;
+    assign valid = (state == DRAW && oe);
 endmodule

--- a/res/README.md
+++ b/res/README.md
@@ -16,6 +16,7 @@ Earthrise drawings in assembler format using extension `.eas`. Use [erasm](../to
 * [16 Squares](drawings/16-squares.eas) - 16 different coloured squares
 * [Doc Examples](drawings/doc-examples.eas) - examples from [Earthrise Programming](../docs/earthrise-programming.md)
 * [Large Shapes](drawings/large-shapes.eas) - some large shapes for testing edge cases
+* [Triangle Fill](drawings/triangle-fill.eas) - many different filled triangles
 
 The _All Shapes_ and _Basic Test_ drawings are also available pre-compiled in $readmemh format.
 

--- a/res/drawings/triangle-fill.eas
+++ b/res/drawings/triangle-fill.eas
@@ -1,0 +1,319 @@
+# Isle.Computer - Earthrise Filled Triangles Example
+# Copyright Will Green and Isle Contributors
+# SPDX-License-Identifier: MIT
+
+# colours
+lca 0xA
+lcb 0xD
+fca 0x4
+fcb 0x5
+
+
+#
+# A slopes steep dec - right angle
+#
+
+# 1a - A-left steep dec - (10,16) -> (4,26) -> (10,26)
+xt  0
+yt  0
+x0 10
+y0 16
+x1  4
+y1 26
+x2 10
+y2 26
+draw trif ca
+
+# 1b - A-left steep dec - (10,16) -> (10,26) -> (4,26)
+xt 16
+yt  0
+x0 10
+y0 16
+x1 10
+y1 26
+x2  4
+y2 26
+draw trif ca
+draw tri ca
+
+# 2a - A-right steep dec - (10,16) -> (4,26) -> (4,16)
+xt 48
+yt  0
+x0 10
+y0 16
+x1  4
+y1 26
+x2  4
+y2 16
+draw trif cb
+
+# 2b - A-right steep dec - (4,16) -> (4,26) -> (10,16)
+xt 64
+yt  0
+x0  4
+y0 16
+x1  4
+y1 26
+x2 10
+y2 16
+draw trif cb
+draw tri cb
+
+
+#
+# A slopes steep dec - not right angle
+#
+
+# 3a - A-left steep dec - (10,16) -> (4,26) -> (10,26)
+xt  0
+yt 16
+x0 11
+y0 16
+x1  4
+y1 26
+x2 10
+y2 26
+draw trif ca
+
+# 3b - A-left steep dec - (10,16) -> (10,26) -> (4,26)
+xt 16
+yt 16
+x0 11
+y0 16
+x1 10
+y1 26
+x2  4
+y2 26
+draw trif ca
+draw tri ca
+
+# 4a - A-right steep dec - (10,16) -> (4,26) -> (4,16)
+xt 48
+yt 16
+x0 10
+y0 16
+x1  4
+y1 26
+x2  3
+y2 16
+draw trif cb
+
+# 4b - A-right steep dec - (4,16) -> (4,26) -> (10,16)
+xt 64
+yt 16
+x0  3
+y0 16
+x1  4
+y1 26
+x2 10
+y2 16
+draw trif cb
+draw tri cb
+
+
+#
+# A slopes shallow dec - right angle
+#
+
+# 5a - A-left shallow dec - (14,16) -> (4,22) -> (14,22)
+xt  0
+yt 48
+x0 14
+y0 16
+x1  4
+y1 22
+x2 14
+y2 22
+draw trif ca
+
+# 5b - A-left shallow dec - (14,16) -> (14,22) -> (4,22)
+xt 16
+yt 48
+x0 14
+y0 16
+x1 14
+y1 22
+x2  4
+y2 22
+draw trif ca
+draw tri ca
+
+# 6a - A-right shallow dec - (14,16) -> (4,22) -> (4,16)
+xt 48
+yt 48
+x0 14
+y0 16
+x1  4
+y1 22
+x2  4
+y2 16
+draw trif cb
+
+# 6b - A-right shallow dec - (4,16) -> (4,22) -> (14,16)
+xt 64
+yt 48
+x0  4
+y0 16
+x1  4
+y1 22
+x2 14
+y2 16
+draw trif cb
+draw tri cb
+
+
+#
+# A slopes steep inc - right angle
+#
+
+# 7a - A-left steep inc - (10,16) -> (10,26) -> (4,16)
+xt  0
+yt 80
+x0 10
+y0 16
+x1 10
+y1 26
+x2  4
+y2 16
+draw trif ca
+
+# 7b - A-left steep inc - (4,16) -> (10,26) -> (10,16)
+xt 16
+yt 80
+x0  4
+y0 16
+x1 10
+y1 26
+x2 10
+y2 16
+draw trif ca
+draw tri ca
+
+# 8a - A-right steep inc - (4,16) -> (4,26) -> (10,26)
+xt 48
+yt 80
+x0  4
+y0 16
+x1  4
+y1 26
+x2 10
+y2 26
+draw trif cb
+
+# 8b - A-right steep inc - (4,16) -> (10,26) -> (4,26)
+xt 64
+yt 80
+x0  4
+y0 16
+x1 10
+y1 26
+x2  4
+y2 26
+draw trif cb
+draw tri cb
+
+
+#
+# A slopes shallow inc - right angle
+#
+
+# 9a - A-left shallow inc - (14,16) -> (14,22) -> (4,16)
+xt  0
+yt 112
+x0 14
+y0 16
+x1 14
+y1 22
+x2  4
+y2 16
+draw trif ca
+
+# 9b - A-left shallow inc - (4,16) -> (14,22) -> (14,16)
+xt 16
+yt 112
+x0  4
+y0 16
+x1 14
+y1 22
+x2 14
+y2 16
+draw trif ca
+draw tri ca
+
+# 10a - A-right shallow inc - (4,16) -> (4,22) -> (14,22)
+xt 48
+yt 112
+x0  4
+y0 16
+x1  4
+y1 22
+x2 14
+y2 22
+draw trif cb
+
+# 10b - A-right shallow inc - (4,16) -> (14,22) -> (4,22)
+xt 64
+yt 112
+x0  4
+y0 16
+x1 14
+y1 22
+x2  4
+y2 22
+draw trif cb
+draw tri cb
+
+
+#
+# B slopes
+#
+
+# 11 - B-left steep dec, shallow inc - (12,16) -> (6,26) -> (16,32)
+xt 127
+yt 16
+x0 12
+y0 16
+x1  6
+y1 26
+x2 16
+y2 32
+draw trif ca
+
+# 12 - B-right steep dec, shallow inc - (6,32) -> (10,16) -> (16,26)
+xt 143
+yt 16
+x0  6
+y0 32
+x1 10
+y1 16
+x2 16
+y2 26
+draw trif cb
+
+# 13 - B-left shallow dec, steep inc - (16,20) -> (4,24) -> (8,36)
+xt 128
+yt 32
+x0 16
+y0 20
+x1  4
+y1 24
+x2  8
+y2 36
+draw trif ca
+
+# 14 - B-right shallow dec, steep inc - (4,20) -> (16,24) -> (12,36)
+xt 144
+yt 32
+x0  4
+y0 20
+x1 16
+y1 24
+x2 12
+y2 36
+draw trif cb
+
+
+#
+# stop
+#
+stop

--- a/res/drawings/triangle-fill.eas
+++ b/res/drawings/triangle-fill.eas
@@ -312,6 +312,16 @@ x2 12
 y2 36
 draw trif cb
 
+# 15 - minimal triangle - (1,0) -> (0,1) -> (2,1)
+xt 144
+yt 16
+x0 1
+y0 0
+x1 0
+y1 1
+x2 2
+y2 1
+draw trif cb
 
 #
 # stop


### PR DESCRIPTION
Refactor Earthrise 2D drawing engine. Reduces Verilog LOC by 79 while adding new functionality.

  - add Earthrise enable signal `en` for bus arbitration with CPU
  - remove cross product from Earthrise triangle rendering
  - add VERILOG_DEBUG to control Verilog debug from Verilator
  - add `cycle_cnt` to Earthrise to report execution cycles
  - remove done signals from primitive shapes
  - use Earthrise enable to control drawing rate in `ch03.v`
  - add triangle fill drawing example

Removes the need for two multipliers (MULT18X18D on ECP5) and increases max ECP5 frequency from 85 to 125 MHz (ch03 example).