### PR TITLE
Improve ECP5 DVI Generator

### DIFF
--- a/hardware/arch/ecp5/dvi_generator.v
+++ b/hardware/arch/ecp5/dvi_generator.v
@@ -19,7 +19,7 @@ module dvi_generator (
     output wire ch0_dout,        // channel 0 - serial TMDS
     output wire ch1_dout,        // channel 1 - serial TMDS
     output wire ch2_dout,        // channel 2 - serial TMDS
-    output reg  clk_dout         // clock channel - serial TMDS
+    output wire clk_dout         // clock channel - serial TMDS
     );
 
     wire [9:0] tmds_ch0, tmds_ch1, tmds_ch2;
@@ -51,18 +51,25 @@ module dvi_generator (
         .tmds(tmds_ch2)
     );
 
+    // use a separate ring counter for each channel to reduce fanout
+    reg [4:0] shift5_ch0 = 5'b00001;
+    reg [4:0] shift5_ch1 = 5'b00001;
+    reg [4:0] shift5_ch2 = 5'b00001;
+
     reg [9:0] ch0_shift, ch1_shift, ch2_shift;
-    reg [4:0] shift5 = 1;  // 5-bit circular shift buffer
+
+    // shift 2 bits of TMDS data every cycle; load new TMDS data every 5 cycles
     always @(posedge clk_pix_5x) begin
-        shift5 <= {shift5[3:0], shift5[4]};
-        ch0_shift <= shift5[4] ? tmds_ch0 : ch0_shift >> 2;  // shift two bits for DDR
-        ch1_shift <= shift5[4] ? tmds_ch1 : ch1_shift >> 2;
-        ch2_shift <= shift5[4] ? tmds_ch2 : ch2_shift >> 2;
+        shift5_ch0 <= {shift5_ch0[3:0], shift5_ch0[4]};
+        shift5_ch1 <= {shift5_ch1[3:0], shift5_ch1[4]};
+        shift5_ch2 <= {shift5_ch2[3:0], shift5_ch2[4]};
+        ch0_shift <= shift5_ch0[4] ? tmds_ch0 : ch0_shift >> 2;  // shift two bits for DDR
+        ch1_shift <= shift5_ch1[4] ? tmds_ch1 : ch1_shift >> 2;
+        ch2_shift <= shift5_ch2[4] ? tmds_ch2 : ch2_shift >> 2;
     end
 
     ODDRX1F serialize_ch0 (.D0(ch0_shift[0]), .D1(ch0_shift[1]), .Q(ch0_dout), .SCLK(clk_pix_5x), .RST(1'b0));
     ODDRX1F serialize_ch1 (.D0(ch1_shift[0]), .D1(ch1_shift[1]), .Q(ch1_dout), .SCLK(clk_pix_5x), .RST(1'b0));
     ODDRX1F serialize_ch2 (.D0(ch2_shift[0]), .D1(ch2_shift[1]), .Q(ch2_dout), .SCLK(clk_pix_5x), .RST(1'b0));
-
-    always @(*) clk_dout = clk_pix;  // clock isn't following same path as other channels
+    ODDRX1F serialize_clk (.D0(1'b1),         .D1(1'b0),         .Q(clk_dout), .SCLK(clk_pix),    .RST(1'b0));
 endmodule


### PR DESCRIPTION
Improve the ECP5 DVI Generator:
* separate ring counter for each TMDS channel for better routing
* reduce skew by sending clock channel through ODDRX1F
* add explanatory comments

This change significantly improves timing slack in the clk_pix_5x clock domain.

Typical nextpnr before change (note the routing):

```
Info: Critical path report for clock '$glbnet$clk_pix_5x' (posedge -> posedge):
Info:       type curr  total name
Info:   clk-to-q  0.40  0.40 Source dvi_out.shift5_TRELLIS_FF_Q.Q
Info:    routing  0.67  1.06 Net dvi_out.shift5[4] (59,4) -> (59,5)
Info:                          Sink dvi_out.ch2_shift_TRELLIS_FF_Q_9_LSR_LUT4_Z.D
Info:                          Defined in:
Info:                               ../../../hardware/arch/ecp5/dvi_generator.v:55.15-55.21
Info:      logic  0.18  1.24 Source dvi_out.ch2_shift_TRELLIS_FF_Q_9_LSR_LUT4_Z.F
Info:    routing  1.58  2.82 Net dvi_out.ch2_shift_TRELLIS_FF_Q_9_LSR (59,5) -> (32,6)
Info:                          Sink dvi_out.ch2_shift_TRELLIS_FF_Q_9.LSR
Info:      setup  0.29  3.10 Source dvi_out.ch2_shift_TRELLIS_FF_Q_9.LSR
Info: 0.86 ns logic, 2.24 ns routing
```

And after:

```
Info: Critical path report for clock '$glbnet$clk_pix_5x' (posedge -> posedge):
Info:       type curr  total name
Info:   clk-to-q  0.40  0.40 Source dvi_out.shift5_ch0_TRELLIS_FF_Q.Q
Info:    routing  0.74  1.13 Net dvi_out.shift5_ch0[4] (95,2) -> (95,5)
Info:                          Sink dvi_out.ch0_shift_TRELLIS_FF_Q_9_LSR_LUT4_Z.D
Info:                          Defined in:
Info:                               ../../../hardware/arch/ecp5/dvi_generator.v:55.15-55.25
Info:      logic  0.18  1.31 Source dvi_out.ch0_shift_TRELLIS_FF_Q_9_LSR_LUT4_Z.F
Info:    routing  0.24  1.55 Net dvi_out.ch0_shift_TRELLIS_FF_Q_9_LSR (95,5) -> (95,5)
Info:                          Sink dvi_out.ch0_shift_TRELLIS_FF_Q_9.LSR
Info:      setup  0.29  1.84 Source dvi_out.ch0_shift_TRELLIS_FF_Q_9.LSR
Info: 0.86 ns logic, 0.98 ns routing
```