### PR TITLE
clk_5x / DVI gen improvements

### DIFF
--- a/hardware/arch/ecp5/dvi_generator.v
+++ b/hardware/arch/ecp5/dvi_generator.v
@@ -22,54 +22,58 @@ module dvi_generator (
     output wire clk_dout         // clock channel - serial TMDS
     );
 
-    wire [9:0] tmds_ch0, tmds_ch1, tmds_ch2;
+    wire [9:0] ch0_tmds, ch1_tmds, ch2_tmds;
 
-    tmds_encoder encode_ch0 (
+    tmds_encoder ch0_encoder (
         .clk_pix(clk_pix),
         .rst_pix(rst_pix),
         .din(ch0_din),
         .ctrl_in(ch0_ctrl),
         .de(de),
-        .tmds(tmds_ch0)
+        .tmds(ch0_tmds)
     );
 
-    tmds_encoder encode_ch1 (
+    tmds_encoder ch1_encoder (
         .clk_pix(clk_pix),
         .rst_pix(rst_pix),
         .din(ch1_din),
         .ctrl_in(ch1_ctrl),
         .de(de),
-        .tmds(tmds_ch1)
+        .tmds(ch1_tmds)
     );
 
-    tmds_encoder encode_ch2 (
+    tmds_encoder ch2_encoder (
         .clk_pix(clk_pix),
         .rst_pix(rst_pix),
         .din(ch2_din),
         .ctrl_in(ch2_ctrl),
         .de(de),
-        .tmds(tmds_ch2)
+        .tmds(ch2_tmds)
     );
 
     // use a separate ring counter for each channel to reduce fanout
-    reg [4:0] shift5_ch0 = 5'b00001;
-    reg [4:0] shift5_ch1 = 5'b00001;
-    reg [4:0] shift5_ch2 = 5'b00001;
-
-    reg [9:0] ch0_shift, ch1_shift, ch2_shift;
-
-    // shift 2 bits of TMDS data every cycle; load new TMDS data every 5 cycles
+    reg [4:0] ch0_ring5 = 5'b00001;
+    reg [4:0] ch1_ring5 = 5'b00001;
+    reg [4:0] ch2_ring5 = 5'b00001;
     always @(posedge clk_pix_5x) begin
-        shift5_ch0 <= {shift5_ch0[3:0], shift5_ch0[4]};
-        shift5_ch1 <= {shift5_ch1[3:0], shift5_ch1[4]};
-        shift5_ch2 <= {shift5_ch2[3:0], shift5_ch2[4]};
-        ch0_shift <= shift5_ch0[4] ? tmds_ch0 : ch0_shift >> 2;  // shift two bits for DDR
-        ch1_shift <= shift5_ch1[4] ? tmds_ch1 : ch1_shift >> 2;
-        ch2_shift <= shift5_ch2[4] ? tmds_ch2 : ch2_shift >> 2;
+        ch0_ring5 <= {ch0_ring5[3:0], ch0_ring5[4]};
+        ch1_ring5 <= {ch1_ring5[3:0], ch1_ring5[4]};
+        ch2_ring5 <= {ch2_ring5[3:0], ch2_ring5[4]};
     end
 
-    ODDRX1F serialize_ch0 (.D0(ch0_shift[0]), .D1(ch0_shift[1]), .Q(ch0_dout), .SCLK(clk_pix_5x), .RST(1'b0));
-    ODDRX1F serialize_ch1 (.D0(ch1_shift[0]), .D1(ch1_shift[1]), .Q(ch1_dout), .SCLK(clk_pix_5x), .RST(1'b0));
-    ODDRX1F serialize_ch2 (.D0(ch2_shift[0]), .D1(ch2_shift[1]), .Q(ch2_dout), .SCLK(clk_pix_5x), .RST(1'b0));
-    ODDRX1F serialize_clk (.D0(1'b1),         .D1(1'b0),         .Q(clk_dout), .SCLK(clk_pix),    .RST(1'b0));
+    // output 2 bits of TMDS data every cycle; load new TMDS data every 5 cycles
+    reg [9:0] ch0_shift = 10'b0;
+    reg [9:0] ch1_shift = 10'b0;
+    reg [9:0] ch2_shift = 10'b0;
+    always @(posedge clk_pix_5x) begin
+        ch0_shift <= ch0_ring5[4] ? ch0_tmds : ch0_shift >> 2;  // shift two bits for DDR
+        ch1_shift <= ch1_ring5[4] ? ch1_tmds : ch1_shift >> 2;
+        ch2_shift <= ch2_ring5[4] ? ch2_tmds : ch2_shift >> 2;
+    end
+
+    // DDR output for three colour channels (and clock to avoid skew)
+    ODDRX1F ch0_oddr (.D0(ch0_shift[0]), .D1(ch0_shift[1]), .Q(ch0_dout), .SCLK(clk_pix_5x), .RST(1'b0));
+    ODDRX1F ch1_oddr (.D0(ch1_shift[0]), .D1(ch1_shift[1]), .Q(ch1_dout), .SCLK(clk_pix_5x), .RST(1'b0));
+    ODDRX1F ch2_oddr (.D0(ch2_shift[0]), .D1(ch2_shift[1]), .Q(ch2_dout), .SCLK(clk_pix_5x), .RST(1'b0));
+    ODDRX1F clk_oddr (.D0(1'b1),         .D1(1'b0),         .Q(clk_dout), .SCLK(clk_pix),    .RST(1'b0));
 endmodule

--- a/hardware/arch/xc7/clock2_gen.v
+++ b/hardware/arch/xc7/clock2_gen.v
@@ -54,7 +54,7 @@ module clock2_gen #(
 
     // explicitly buffer output clocks
     BUFG bufg_clk(.I(clk_unbuf), .O(clk_out));
-    BUFG bufg_clk_5x_out(.I(clk_5x_unbuf), .O(clk_5x_out));
+    BUFIO bufio_clk_5x(.I(clk_5x_unbuf), .O(clk_5x_out));
 
     // ensure clock lock is synced with output clock
     reg locked_sync;

--- a/hardware/arch/xc7/dvi_generator.v
+++ b/hardware/arch/xc7/dvi_generator.v
@@ -22,60 +22,60 @@ module dvi_generator (
     output wire clk_dout         // clock channel - serial TMDS
     );
 
-    wire [9:0] tmds_ch0, tmds_ch1, tmds_ch2;
+    wire [9:0] ch0_tmds, ch1_tmds, ch2_tmds;
 
-    tmds_encoder encode_ch0 (
+    tmds_encoder ch0_encoder (
         .clk_pix(clk_pix),
         .rst_pix(rst_pix),
         .din(ch0_din),
         .ctrl_in(ch0_ctrl),
         .de(de),
-        .tmds(tmds_ch0)
+        .tmds(ch0_tmds)
     );
 
-    tmds_encoder encode_ch1 (
+    tmds_encoder ch1_encoder (
         .clk_pix(clk_pix),
         .rst_pix(rst_pix),
         .din(ch1_din),
         .ctrl_in(ch1_ctrl),
         .de(de),
-        .tmds(tmds_ch1)
+        .tmds(ch1_tmds)
     );
 
-    tmds_encoder encode_ch2 (
+    tmds_encoder ch2_encoder (
         .clk_pix(clk_pix),
         .rst_pix(rst_pix),
         .din(ch2_din),
         .ctrl_in(ch2_ctrl),
         .de(de),
-        .tmds(tmds_ch2)
+        .tmds(ch2_tmds)
     );
 
-    oserdes_10b serialize_ch0 (
+    oserdes_10b ch0_oserdes (
         .clk(clk_pix),
         .clk_hs(clk_pix_5x),
         .rst(rst_pix),
-        .data_in(tmds_ch0),
+        .data_in(ch0_tmds),
         .serial_out(ch0_dout)
     );
 
-    oserdes_10b serialize_ch1 (
+    oserdes_10b ch1_oserdes (
         .clk(clk_pix),
         .clk_hs(clk_pix_5x),
         .rst(rst_pix),
-        .data_in(tmds_ch1),
+        .data_in(ch1_tmds),
         .serial_out(ch1_dout)
     );
 
-    oserdes_10b serialize_ch2 (
+    oserdes_10b ch2_oserdes (
         .clk(clk_pix),
         .clk_hs(clk_pix_5x),
         .rst(rst_pix),
-        .data_in(tmds_ch2),
+        .data_in(ch2_tmds),
         .serial_out(ch2_dout)
     );
 
-    oserdes_10b serialize_chc (
+    oserdes_10b clk_oserdes (
         .clk(clk_pix),
         .clk_hs(clk_pix_5x),
         .rst(rst_pix),


### PR DESCRIPTION
* Use Use BUFIO for clk_5x to improve TMDS output timing
* Improve signal naming for DVI generators