### PR TITLE
Use newer RISC-V toolchain on macOS

### DIFF
--- a/software/book/ch05/Makefile
+++ b/software/book/ch05/Makefile
@@ -5,8 +5,7 @@
 MAKEFLAGS += --no-builtin-rules --no-builtin-variables
 
 # BIN_PREFIX needs adjusting on some platforms
-#  e.g. riscv64-elf on Arch Linux and riscv64-linux-gnu on Fedora
-BIN_PREFIX := riscv64-unknown-elf
+BIN_PREFIX := riscv64-elf
 
 # arch settings
 MARCH := rv32i  # RV32I for chapter 5
@@ -21,6 +20,11 @@ LD      := $(BIN_PREFIX)-ld
 OBJDUMP := $(BIN_PREFIX)-objdump
 OBJCOPY := $(BIN_PREFIX)-objcopy
 HEXDUMP := hexdump
+
+# check for toolchain
+ifeq (,$(shell command -v $(AS) 2>/dev/null))
+$(error $(AS) not found. Check your BIN_PREFIX or install a RISC-V toolchain)
+endif
 
 # find sources and derive program names and .mem targets
 SRCS  := $(wildcard *.s)

--- a/software/book/ch05/README.md
+++ b/software/book/ch05/README.md
@@ -24,13 +24,15 @@ Install a RISC-V toolchain:
 * Debian/Ubuntu/Pop!_OS: `apt install gcc-riscv64-unknown-elf`
 * Arch Linux: `pacman -S riscv64-elf-gcc`
 * Fedora: `dnf install gcc-riscv64-linux-gnu`
-* macOS: `brew install riscv-gnu-toolchain`
+* macOS: `brew install riscv64-elf-gcc`
 
 Windows users can run a RISC-V toolchain under Windows Subsystem for Linux (WSL).
 
+NB. Fedora doesn't provide a bare metal RISC-V toolchain, but `gcc-riscv64-linux-gnu` works for Isle (though it doesn't include newlib).
+
 ### Build
 
-Before building, Arch Linux and Fedora users need to edit `BIN_PREFIX` in `isle/software/book/ch05/Makefile`.
+Before building, ensure `BIN_PREFIX` in `isle/software/book/ch05/Makefile` matches your toolchain (the default is correct for Arch Linux and macOS as installed above).
 
 To build all the chapter 5 software:
 

--- a/software/book/ch06/Makefile
+++ b/software/book/ch06/Makefile
@@ -5,8 +5,7 @@
 MAKEFLAGS += --no-builtin-rules --no-builtin-variables
 
 # BIN_PREFIX needs adjusting on some platforms
-#  e.g. riscv64-elf on Arch Linux and riscv64-linux-gnu on Fedora
-BIN_PREFIX := riscv64-unknown-elf
+BIN_PREFIX := riscv64-elf
 
 # arch settings
 MARCH := rv32im  # RV32IM for chapter 6
@@ -30,6 +29,11 @@ INCS     := $(wildcard include/*.inc)
 SRCS     := $(wildcard *.s)
 MEMS     := $(SRCS:.s=.mem)
 NAMES    := $(SRCS:.s=)
+
+# check for toolchain
+ifeq (,$(shell command -v $(AS) 2>/dev/null))
+$(error $(AS) not found. Check your BIN_PREFIX or install a RISC-V toolchain)
+endif
 
 # lib archive
 LIB_ISLE := lib/libisle.a

--- a/software/book/ch06/README.md
+++ b/software/book/ch06/README.md
@@ -16,7 +16,7 @@ There's a blog post covering [Chapter 6 Software](https://projectf.io/isle/ch06-
 
 If you've previously built [chapter 5 software](../ch05/README.md), you have everything you need. Consult the [Isle Software Build](https://projectf.io/isle/software-build.html) guide for advice on setting up the toolchain.
 
-Before building, Arch Linux and Fedora users need to edit `BIN_PREFIX` in `isle/software/book/ch06/Makefile`.
+Before building, ensure `BIN_PREFIX` in `isle/software/book/ch06/Makefile` matches your toolchain.
 
 To build all the chapter 6 software:
 


### PR DESCRIPTION
* use brew riscv64-elf-gcc in place of riscv-gnu-toolchain
* adds friendly error message if `BIN_PREFIX` is incorrect.