### PR TITLE
Display HW Reg & canv_disp_agu Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.ip_user_files
 *.mcs
 *.prm
+*.rpt
 *.runs
 *.sim
 *.srcs

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ __pycache__
 *.vcd
 cocotb-venv
 
+# Surfer
+*.surf.ron
+*.ron
+
 # Mac
 .DS_Store
 

--- a/boards/nexys_video/README.md
+++ b/boards/nexys_video/README.md
@@ -2,9 +2,11 @@
 
 Isle supports the Digilent Nexys Video dev board with Xilinx XC7 FPGA. Isle also supports other [dev boards](../).
 
-For the Nexys Video dev board, you need [Vivado](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html). Vivado can also program the Nexys Video, but I recommend using [openFPGALoader](https://github.com/trabucayre/openFPGALoader) as it's simpler and faster.
+For the Nexys Video dev board, you need [Vivado](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html) to build Isle. Vivado can also program the Nexys Video, but I recommend using [openFPGALoader](https://github.com/trabucayre/openFPGALoader) as it's simpler and faster.
 
 If you're new to Isle, the best place to start is [Isle FPGA Computer](http://projectf.io/isle/fpga-computer.html).
+
+_I plan to look at open-source XC7 tools in future._
 
 ## Building
 
@@ -47,7 +49,7 @@ See [Serial to Isle](../../docs/serial-to-isle.md) for advice on connecting to I
 
 The following table shows clock generation parameters for different [display modes](../../hardware/include/display_modes.vh) using the 100 MHz board clock of the Nexys Video.
 
-| Parameter         | 640x480    | 1024x768   | 1366x768   | 1280x720   | 1920x1080  |
+| Parameter         | 640x480    | 1024x768   | 1366x768   | 1280x720   | 1920x1080* |
 | ----------------- | ---------: | ---------: | ---------: | ---------: | ---------: |
 | Isle DISPLAY_MODE | 0          | 1          | 2          | 4          | 5          |
 | Pixel Clock (MHz) | 25.2       | 65         | 72         | 74.25      | 148.5      |
@@ -56,6 +58,27 @@ The following table shows clock generation parameters for different [display mod
 | DIV_5X            | 5.0        | 2.0        | 3.0        | 2.0        | 1.0        |
 | DIV_1X            | 25         | 10         | 15         | 10         | 5          |
 
+_\*1920x1080 does not meet timing on Nexys Video, see discussion, below._
+
 `IN_PERIOD` should always be set to 10.0 (ns) to match the 100 MHz board clock.
 
 NB. VCO (`CLK_IN × MULT_MASTER / DIV_MASTER`) range is 600 - 1200 MHz for Xilinx 7 series speed grade -1.
+
+### 1920x1080p60
+
+I don't recommend using 1080p unless you have a specific requirement for it, such as video capture. Lower resolutions support all Isle features while meeting FPGA timing.
+
+1920x1080p60 is out of spec for Xilinx 7 series FPGAs, but it generally works in practice on the Nexys Video. For 1920x1080p60 (pixel clock 148.5 MHz), the 5x TMDS pixel clock is 742.5 MHz.
+
+We use `BUFIO`, the fastest clock buffer, in the [pixel clock generator](../../hardware/arch/xc7/clock2_gen.v), but its maximum frequency is 600 MHz on speed grade -1 or 680 MHz on faster speed grades ([DS181](https://docs.amd.com/v/u/en-US/ds181_Artix_7_Data_Sheet) table 33).
+
+If we look at the Vivado timing report at 1080p, we can see this issue (1.667 ns is 600 MHz, 1.347 ns is 742.5 MHz):
+
+```
+Check Type  Corner  Lib Pin             Required(ns)  Actual(ns)  Slack(ns)  Location
+Min Period  n/a     OSERDESE2/CLK       1.667         1.347       -0.320     OLOGIC_X1Y140
+```
+
+1920x1080p60 usually works in practice because the specs have to cover the worst-case for the process (variations in the physical FPGA IC), voltage, and temperature. For example, you're probably not running your Nexys Video FPGA at the maximum 85ºC. The Nexys Video board also includes a [TI TMDS141](https://www.ti.com/product/TMDS141) HDMI redriver, so the FPGA only has to drive the TMDS signal a short distance on the PCB.
+
+TVs are generally pickier than computer monitors. If your TV doesn't like running Isle at 1080p, try 720p instead.

--- a/boards/nexys_video/ch01/build.tcl
+++ b/boards/nexys_video/ch01/build.tcl
@@ -41,5 +41,5 @@ synth_design -top "top_${design_name}" -part ${fpga_part} -include_dirs "${lib_d
 opt_design
 place_design
 route_design
-report_timing_summary
+report_timing_summary -file "${design_name}_timing_summary.rpt"
 write_bitstream -force "${design_name}.bit"

--- a/boards/nexys_video/ch02/build.tcl
+++ b/boards/nexys_video/ch02/build.tcl
@@ -37,5 +37,5 @@ synth_design -top "top_${design_name}" -part ${fpga_part} -include_dirs "${lib_d
 opt_design
 place_design
 route_design
-report_timing_summary
+report_timing_summary -file "${design_name}_timing_summary.rpt"
 write_bitstream -force "${design_name}.bit"

--- a/boards/nexys_video/ch03/build.tcl
+++ b/boards/nexys_video/ch03/build.tcl
@@ -44,5 +44,5 @@ synth_design -top "top_${design_name}" -part ${fpga_part} -include_dirs "${lib_d
 opt_design
 place_design
 route_design
-report_timing_summary
+report_timing_summary -file "${design_name}_timing_summary.rpt"
 write_bitstream -force "${design_name}.bit"

--- a/boards/nexys_video/ch04/build.tcl
+++ b/boards/nexys_video/ch04/build.tcl
@@ -40,5 +40,5 @@ synth_design -top "top_${design_name}" -part ${fpga_part} -include_dirs "${lib_d
 opt_design
 place_design
 route_design
-report_timing_summary
+report_timing_summary -file "${design_name}_timing_summary.rpt"
 write_bitstream -force "${design_name}.bit"

--- a/boards/nexys_video/ch05/build.tcl
+++ b/boards/nexys_video/ch05/build.tcl
@@ -43,5 +43,5 @@ synth_design -top "top_${design_name}" -part ${fpga_part} -include_dirs "${lib_d
 opt_design
 place_design
 route_design
-report_timing_summary
+report_timing_summary -file "${design_name}_timing_summary.rpt"
 write_bitstream -force "${design_name}.bit"

--- a/boards/nexys_video/ch06/build.tcl
+++ b/boards/nexys_video/ch06/build.tcl
@@ -49,5 +49,5 @@ synth_design -top "top_${design_name}" -part ${fpga_part} -include_dirs "${lib_d
 opt_design
 place_design
 route_design
-report_timing_summary
+report_timing_summary -file "${design_name}_timing_summary.rpt"
 write_bitstream -force "${design_name}.bit"

--- a/hardware/docs/canv_disp_agu.md
+++ b/hardware/docs/canv_disp_agu.md
@@ -8,11 +8,12 @@ See the [Bitmap Graphics](http://projectf.io/isle/bitmap-graphics.html) blog pos
 
 ## Parameters
 
-* `CORDW` - signed coordinate width (bits)
-* `WORD` - machine word size (bits)
 * `ADDRW` - address width (bits)
-* `BMAP_LAT` - latency for AGU + VRAM + CLUT
+* `CLUT_LAT` - clut display read latency (cycles; min=1)
+* `CORDW` - signed coordinate width (bits)
 * `SHIFTW` - address shift width (bits)
+* `VRAM_LAT` - vram display read latency (cycles; min=1)
+* `WORD` - machine word size (bits)
 
 ## Signals
 
@@ -23,7 +24,7 @@ See the [Bitmap Graphics](http://projectf.io/isle/bitmap-graphics.html) blog pos
 * `frame_start` - frame start flag
 * `line_start` - line start flag
 * (`dx`, `dy`) - display position
-* `addr_base` - canvas base address
+* `addr_base` - canvas base address (word address)
 * `addr_shift` - address shift bits (for colour depth)
 * `win_start` - canvas window start coords
 * `win_end` - canvas window end coords
@@ -33,9 +34,9 @@ Several of these input signals come from the [display sync generator](display_sy
 
 The position of the canvas on the display is set by the window start `win_start` and end `win_end` signals, while horizontal and vertical scale are controlled by `scale`. These signals are discussed in more detail below.
 
-`addr_base` is the base address of the canvas buffer in vram. You can switch this at the start of a frame for double buffering. Or even mid-way through a frame to combine different buffers to form a display.
+`addr_base` is the base _word_ address of the canvas buffer in vram. You can switch this at the start of a frame for double buffering. Or even mid-way through a frame to combine different buffers to form a display.
 
-The `BMAP_LAT` parameter corrects for end-to-end bitmap latency in calculating the address, retrieving data from vram, and looking the colour up in the CLUT. For Isle this should be set to 6. See [display pipeline](#display-pipeline) for further explanation.
+The `VRAM_LAT` and `CLUT_LAT` parameters correct for latency in retrieving data from vram and looking the colour up in the CLUT. For Isle they should both be set to 2. See [display pipeline](#display-pipeline) for further explanation.
 
 The address shift, `addr_shift`, determines how the raw pixel address is split between vram address and pixel index. Because the maximum address shift is 5, the `SHIFTW` parameter is set to 3.
 
@@ -104,7 +105,7 @@ The bitmap display pipeline has three stages:
 2. [vram](vram.md) - returns pixel data
 3. [clut](clut.md) - looks up pixel colour
 
-This process takes several clock cycles. If we don't account for latency, the pixel would be displayed in the wrong position (too far to the right). VRAM and CLUT use brams with additional output registers, hence taking two cycles from address generation to receiving data.
+This process takes several clock cycles. If we don't account for latency, the pixel would be displayed in the wrong position (too far to the right). The vram and clut modules use bram with additional output registers, hence taking two cycles from address generation to receiving data.
 
 Our display controller begins each line with the horizontal blanking internal. This gives us time to prepare the pipeline for the the first pixel, even if it's at x=0.
 

--- a/hardware/gfx/canv_disp_agu.v
+++ b/hardware/gfx/canv_disp_agu.v
@@ -22,7 +22,7 @@ module canv_disp_agu #(
     input  wire line_start,               // line start flag
     input  wire signed [CORDW-1:0] dx,    // horizontal display position
     input  wire signed [CORDW-1:0] dy,    // vertical display position
-    input  wire [ADDRW-1:0] addr_base,    // canvas base address
+    input  wire [ADDRW-1:0] addr_base,    // canvas base address (word address)
     input  wire [SHIFTW-1:0] addr_shift,  // address shift bits
     input  wire [2*CORDW-1:0] win_start,  // canvas window start coords
     input  wire [2*CORDW-1:0] win_end,    // canvas window end coords
@@ -32,28 +32,38 @@ module canv_disp_agu #(
     output reg  paint                     // canvas painting enable (pre-clut)
     );
 
-    localparam AGU_LAT = 2;  // address generation latency (this module)
-    localparam BMAP_LAT = AGU_LAT + VRAM_LAT + CLUT_LAT;  // end-to-end latency for vram read
+    localparam PAINT_LAT = CLUT_LAT + 1;  // +1 for paint reg
+    localparam ADDR_LAT = VRAM_LAT + CLUT_LAT + 2;  // +1 for vram_read reg; +1 for AGU stage 2
 
     // separate y and x from canvas window signals
     reg signed [CORDW-1:0] win_start_y, win_start_x;
     reg signed [CORDW-1:0] win_end_y, win_end_x;
-    reg [CORDW-1:0] scale_y, scale_y0, scale_x, scale_x0;
+    reg [CORDW-1:0] scale_y0, scale_x0;
     always @(*) begin
         {win_start_y, win_start_x} = win_start;
         {win_end_y, win_end_x} = win_end;
         {scale_y0, scale_x0} = scale;
-        scale_x = (scale_x0 == 0) ? 1 : scale_x0;  // if scale is 0, set to 1
-        scale_y = (scale_y0 == 0) ? 1 : scale_y0;
     end
 
-    // paint and vram read area defined by window
+    // register signals to improve timing with hwreg
+    reg [CORDW-1:0] scale_x_minus, scale_y_minus;
+    reg signed [CORDW-1:0] paint_start_x, paint_end_x;
+    reg signed [CORDW-1:0] vram_start_x, vram_end_x;
+    always @(posedge clk_pix) begin
+        scale_x_minus <= (scale_x0 == 0) ? 0 : scale_x0 - 1;
+        scale_y_minus <= (scale_y0 == 0) ? 0 : scale_y0 - 1;
+        paint_start_x <= win_start_x - PAINT_LAT;
+        paint_end_x <= win_end_x - PAINT_LAT;
+        vram_start_x <= win_start_x - ADDR_LAT;
+        vram_end_x <= win_end_x - ADDR_LAT;
+    end
+
+    // register paint and vram read area as defined by window
     reg vram_read;
     wire win_y = (dy >= win_start_y) && (dy < win_end_y);
     always @(posedge clk_pix) begin
-        paint <= (dx >= win_start_x - VRAM_LAT - 1)  // -1 for registering
-              && (dx < win_end_x - VRAM_LAT - 1) && win_y;
-        vram_read <= (dx >= win_start_x-BMAP_LAT) && (dx < win_end_x-BMAP_LAT) && win_y;
+        paint <= (dx >= paint_start_x) && (dx < paint_end_x) && win_y;  // output signal
+        vram_read <= (dx >= vram_start_x) && (dx < vram_end_x) && win_y;  // used in AGU stage 1
     end
 
     // pipelined signals
@@ -70,15 +80,16 @@ module canv_disp_agu #(
             addr_pix <= 0;
             addr_pix_ln <= 0;
         end else if (line_start && (dy > win_start_y)) begin  // after 1st line in paint area
-            if (cnt_y == scale_y-1) begin
+            cnt_x <= 0;  // reset x counter at line start
+            if (cnt_y == scale_y_minus) begin
                 cnt_y <= 0;
                 addr_pix_ln <= addr_pix;  // save line address
             end else begin
                 cnt_y <= cnt_y + 1;
                 addr_pix <= addr_pix_ln;  // restore addr_pix_ln to repeat line
             end
-        end else if (vram_read) begin  // increment address in vram read area
-            if (cnt_x == scale_x-1) begin
+        end else if (vram_read) begin  // increment pixel address in vram read area
+            if (cnt_x == scale_x_minus) begin
                 addr_pix <= addr_pix + 1;
                 cnt_x <= 0;
             end else cnt_x <= cnt_x + 1;

--- a/hardware/gfx/textmode.v
+++ b/hardware/gfx/textmode.v
@@ -42,24 +42,33 @@ module textmode #(
     // separate y and x from text window signals
     reg signed [CORDW-1:0] win_start_y, win_start_x;
     reg signed [CORDW-1:0] win_end_y, win_end_x;
-    reg [CORDW-1:0] scale_y, scale_y0, scale_x, scale_x0;
+    reg [CORDW-1:0] scale_y0, scale_x0;
     always @(*) begin
         {win_start_y, win_start_x} = win_start;
         {win_end_y, win_end_x} = win_end;
         {scale_y0, scale_x0} = scale;
-        scale_x = (scale_x0 == 0) ? 1 : scale_x0;  // if scale is 0, set to 1
-        scale_y = (scale_y0 == 0) ? 1 : scale_y0;
+    end
+
+    // register signals to improve timing with hwreg
+    reg [CORDW-1:0] scale_x_minus, scale_y_minus;
+    reg signed [CORDW-1:0] paint_start_x, paint_end_x;
+    reg signed [CORDW-1:0] win_end_x_minus, win_end_y_minus;
+    reg signed [CORDW-1:0] draw_start_x_minus;   // draw start depends on window and latency
+    always @(posedge clk_pix) begin
+        scale_x_minus <= (scale_x0 == 0) ? 0 : scale_x0 - 1;
+        scale_y_minus <= (scale_y0 == 0) ? 0 : scale_y0 - 1;
+        paint_start_x <= win_start_x - CLUT_LAT - 1;  // -1 for registering
+        paint_end_x <= win_end_x - CLUT_LAT - 1;
+        win_end_x_minus <= win_end_x - 1;
+        win_end_y_minus <= win_end_y - 1;
+        draw_start_x_minus <= win_start_x - PIX_LAT - CLUT_LAT - 1;  // -1 for state trans to DRAW
     end
 
     // paint area defined by window
     wire win_y = (dy >= win_start_y) && (dy < win_end_y);
     always @(posedge clk_pix) begin
-        paint <= (dx >= win_start_x - CLUT_LAT - 1)  // -1 for registering
-              && (dx < win_end_x - CLUT_LAT - 1) && win_y;
+        paint <= (dx >= paint_start_x) && (dx < paint_end_x) && win_y;
     end
-
-    // draw start depends on window and latency
-    wire signed [CORDW-1:0] draw_start_x = win_start_x - PIX_LAT - CLUT_LAT;
 
     // bit widths
     localparam GLYPH_HEIGHT_W = $clog2(GLYPH_HEIGHT);
@@ -87,8 +96,8 @@ module textmode #(
 
     // glyph end signals
     /* verilator lint_off WIDTHEXPAND */
-    wire glyph_x_end = (gx == GLYPH_WIDTH-1  && cnt_x == scale_x-1);
-    wire glyph_y_end = (gy == GLYPH_HEIGHT-1 && cnt_y == scale_y-1);
+    wire glyph_x_end = (gx == GLYPH_WIDTH-1  && cnt_x == scale_x_minus);
+    wire glyph_y_end = (gy == GLYPH_HEIGHT-1 && cnt_y == scale_y_minus);
     /* verilator lint_on WIDTHEXPAND */
 
     // state machine
@@ -116,21 +125,21 @@ module textmode #(
                 cnt_y <= 0;
             end
             AWAIT: begin
-                if (dx == draw_start_x - 1) state <= DRAW;  // -1 for transition to DRAW
+                if (dx == draw_start_x_minus) state <= DRAW;
                 colr_fg <= tram_data[WORD-CIDXW-1:WORD-2*CIDXW];
                 colr_bg <= tram_data[WORD-1:WORD-CIDXW];
                 pix_line_reg <= pix_line;
                 ucp <= tram_data[UCPW-1:0];
             end
             DRAW: begin
-                if (tx == text_hres || dx >= win_end_x-1) begin
-                    if (ty == text_vres || dy >= win_end_y-1) state <= IDLE;
+                if (tx == text_hres || dx >= win_end_x_minus) begin
+                    if (ty == text_vres || dy >= win_end_y_minus) state <= IDLE;
                     else if (glyph_y_end) state <= CHR_LINE;
                     else state <= SCR_LINE;
                 end
 
                 // step through horizontal pixels
-                if (cnt_x == scale_x-1) begin
+                if (cnt_x == scale_x_minus) begin
                     cnt_x <= 0;
                     /* verilator lint_off WIDTHEXPAND */
                     gx <= (gx == GLYPH_WIDTH-1) ? 0 : gx + 1;
@@ -171,7 +180,7 @@ module textmode #(
                 cnt_x <= 0;
 
                 // step through lines (vertical pixels)
-                if (cnt_y == scale_y-1) begin
+                if (cnt_y == scale_y_minus) begin
                     cnt_y <= 0;
                     /* verilator lint_off WIDTHEXPAND */
                     gy <= (gy == GLYPH_HEIGHT-1) ? 0 : gy + 1;

--- a/hardware/tests/README.md
+++ b/hardware/tests/README.md
@@ -15,7 +15,7 @@ Ensure you've [installed simulators and cocotb](#install-simulators) and sourced
 
 ```shell
 cd isle/hardware/tests
-source hw-tests-venv/bin/activate
+source .venv/bin/activate
 ```
 
 Run tests using `make` within your chosen directory. For example, to test the TMDS encoder:
@@ -25,7 +25,7 @@ cd gfx
 make tmds_encoder
 ```
 
-Use `WAVES=1` to generate [FST](https://blog.timhutt.co.uk/fst_spec/) waveform files.
+Use `WAVES=1` (case sensitive) to generate [FST](https://blog.timhutt.co.uk/fst_spec/) waveform files.
 
 For example, the following creates `sim_build/clut/clut.fst`:
 
@@ -92,14 +92,14 @@ Isle requires cocotb 2.0+. I recommend installing cocotb inside a venv using the
 
 ```shell
 cd isle/hardware/tests
-python3 -m venv hw-tests-venv
+python3 -m venv .venv
 
-source hw-tests-venv/bin/activate
+source .venv/bin/activate
 pip3 install -r requirements.txt
 ```
 
 Troubleshooting:
 
-* The latest version of Python isn't necessarily supported (cocotb 2.0 doesn't support Python 14).
+* The latest version of Python isn't necessarily supported by cocotb - check [supported python versions](https://docs.cocotb.org/en/stable/platform_support.html#supported-python-versions) (cocotb.org)
 * If you're having issues running cocotb on macOS, try using brew Python instead of the system one.
 * I don't recommend using the version of cocotb from _OSS CAD Suite_ because it's not a stable release.

--- a/hardware/tests/book/ch06.py
+++ b/hardware/tests/book/ch06.py
@@ -42,8 +42,8 @@ async def reset_pix_dut(dut):
 
 
 @cocotb.test()  # pylint: disable=no-value-for-parameter
-async def ch05(dut):
-    """ch05 test"""
+async def ch06(dut):
+    """ch06 test"""
     cocotb.start_soon(Clock(dut.clk_sys, SYS_TIME, unit="ns").start())
     cocotb.start_soon(Clock(dut.clk_pix, PIX_TIME, unit="ns").start())
     await reset_sys_dut(dut)

--- a/hardware/tests/gfx/canv_disp_agu.mk
+++ b/hardware/tests/gfx/canv_disp_agu.mk
@@ -13,7 +13,7 @@ HARDWARE = $(PWD)/../..
 VERILOG_SOURCES += $(HARDWARE)/gfx/${DUT}.v
 
 # pass Verilog module parameters to simulator
-COMPILE_ARGS += -P${DUT}.ADDRW=8 -P${DUT}.CLUT_LAT=2 -P${DUT}.SHIFTW=3 -P${DUT}.VRAM_LAT=2
+COMPILE_ARGS += -P${DUT}.ADDRW=14 -P${DUT}.CLUT_LAT=1 -P${DUT}.SHIFTW=3 -P${DUT}.VRAM_LAT=3
 
 # each test needs its own build dir and results file
 COCOTB_RESULTS_FILE = results_${DUT}.xml

--- a/hardware/tests/gfx/canv_disp_agu.py
+++ b/hardware/tests/gfx/canv_disp_agu.py
@@ -168,8 +168,10 @@ async def canv_disp_agu_addr(dut, params):
                 )
 
                 line_s = (params.win_end.x - params.win_start.x) // scale_x
-                expected_addr_pix = ((dy - params.win_start.y) // scale_y) * line_s \
+                expected_addr_pix = (
+                    ((dy - params.win_start.y) // scale_y) * line_s
                     + ((dx + ADDR_LAT - params.win_start.x) // scale_x)
+                )
 
                 expected_addr = params.addr_base + (expected_addr_pix >> params.addr_shift)
 

--- a/hardware/tests/gfx/canv_disp_agu.py
+++ b/hardware/tests/gfx/canv_disp_agu.py
@@ -26,6 +26,7 @@ Y_MAX = 7
 # latencies (must match canv_disp_agu.mk)
 CLUT_LAT = 1
 VRAM_LAT = 3
+ADDR_LAT = CLUT_LAT + VRAM_LAT
 
 @dataclass(frozen=True)
 class CanvasParams:
@@ -110,13 +111,17 @@ async def canv_disp_agu_paint(dut, params):
                 await ReadOnly()
                 actual_paint = dut.paint.value
 
-                in_window = (params.win_start.y <= dy < params.win_end.y
-                    and params.win_start.x <= dx+CLUT_LAT < params.win_end.x)
+                in_window = (
+                    params.win_start.y <= dy < params.win_end.y
+                    and params.win_start.x <= dx+CLUT_LAT < params.win_end.x
+                )
                 expected_paint = Logic(1) if in_window else Logic(0)
 
                 if actual_paint.is_resolvable:
-                    assert actual_paint == expected_paint, \
-                        f"paint: '{actual_paint}' is not expected '{expected_paint}' at ({dx}, {dy}) in frame={frame}!"
+                    assert actual_paint == expected_paint, (
+                        f"paint: '{actual_paint}' is not expected '{expected_paint}'"
+                        f"at ({dx}, {dy}) in frame={frame}!"
+                    )
 
                 await RisingEdge(dut.clk_pix)
 
@@ -151,16 +156,16 @@ async def canv_disp_agu_addr(dut, params):
                 dut.line_start.value = 1 if dx == X_MIN else 0
 
                 await ReadOnly()
-                actual_addr_pix = dut.addr_pix.value
                 actual_addr = dut.addr.value
                 actual_pix_id = dut.pix_id.value
 
                 scale_x = params.scale.x if params.scale.x > 0 else 1
                 scale_y = params.scale.y if params.scale.y > 0 else 1
 
-                ADDR_LAT = CLUT_LAT + VRAM_LAT
-                vram_read = (params.win_start.y <= dy < params.win_end.y
-                    and params.win_start.x <= dx+ADDR_LAT < params.win_end.x)
+                vram_read = (
+                    params.win_start.y <= dy < params.win_end.y
+                    and params.win_start.x <= dx+ADDR_LAT < params.win_end.x
+                )
 
                 line_s = (params.win_end.x - params.win_start.x) // scale_x
                 expected_addr_pix = ((dy - params.win_start.y) // scale_y) * line_s \
@@ -172,9 +177,13 @@ async def canv_disp_agu_addr(dut, params):
                 expected_pix_id = expected_addr_pix & pix_id_mask
 
                 if vram_read and actual_addr.is_resolvable and actual_pix_id.is_resolvable:
-                    assert int(actual_addr) == expected_addr, \
-                        f"addr: '{int(actual_addr)}' is not expected '{expected_addr}' at ({dx}, {dy}) in frame={frame}!"
-                    assert int(actual_pix_id) == expected_pix_id, \
-                        f"pix_id: '{int(actual_pix_id)}' is not expected '{expected_pix_id}' at ({dx}, {dy}) in frame={frame}!"
+                    assert int(actual_addr) == expected_addr, (
+                        f"addr: '{int(actual_addr)}' is not expected '{expected_addr}'"
+                        f"at ({dx}, {dy}) in frame={frame}!"
+                    )
+                    assert int(actual_pix_id) == expected_pix_id, (
+                        f"pix_id: '{int(actual_pix_id)}' is not expected '{expected_pix_id}'"
+                        f"at ({dx}, {dy}) in frame={frame}!"
+                    )
 
                 await RisingEdge(dut.clk_pix)

--- a/hardware/tests/gfx/canv_disp_agu.py
+++ b/hardware/tests/gfx/canv_disp_agu.py
@@ -4,9 +4,15 @@
 
 """canv_disp_agu Test Bench (cocotb)"""
 
+from dataclasses import dataclass
+
 import cocotb
+
 from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge
+from cocotb.triggers import ReadOnly, RisingEdge
+from cocotb.types import Logic
+
+from tests.helpers import Coords
 
 # clock frequencies
 PIX_TIME = 100  # 10 MHz
@@ -17,10 +23,65 @@ X_MAX = 15
 Y_MIN = -2
 Y_MAX = 7
 
-@cocotb.test()  # pylint: disable=no-value-for-parameter
-async def address_scale_0x(dut):
-    """Test address calculation."""
+# latencies (must match canv_disp_agu.mk)
+CLUT_LAT = 1
+VRAM_LAT = 3
 
+@dataclass(frozen=True)
+class CanvasParams:
+    """Hold canvas parameters."""
+    addr_base: int
+    addr_shift: int
+    win_start: Coords
+    win_end: Coords
+    scale: Coords
+
+# test params
+SCALE_0X0Y = CanvasParams (
+    addr_base = 0x0,
+    addr_shift = 3,  # 16 colour
+    win_start = Coords(x=0, y=0),
+    win_end = Coords(x=X_MAX+1, y=Y_MAX+1),
+    scale = Coords(x=0, y=0),  # hardware should treat as 1x
+)
+
+SCALE_1X1Y = CanvasParams (
+    addr_base = 0xC03,
+    addr_shift = 5,  # 2 colour
+    win_start = Coords(x=2, y=1),
+    win_end = Coords(x=X_MAX+1, y=Y_MAX+1),
+    scale = Coords(x=1, y=1),
+)
+
+SCALE_2X2Y = CanvasParams (
+    addr_base = 0x201,
+    addr_shift = 4,  # 4 colour
+    win_start = Coords(x=1, y=1),
+    win_end = Coords(x=X_MAX, y=Y_MAX),
+    scale = Coords(x=2, y=2),
+)
+
+SCALE_4X4Y = CanvasParams (
+    addr_base = 0x2000,
+    addr_shift = 3,  # 16 colour
+    win_start = Coords(x=0, y=0),
+    win_end = Coords(x=X_MAX+1, y=Y_MAX+1),
+    scale = Coords(x=4, y=4),
+)
+
+SCALE_3X5Y = CanvasParams (
+    addr_base = 0x1FFF,
+    addr_shift = 2,  # 256 colour
+    win_start = Coords(x=0, y=0),
+    win_end = Coords(x=X_MAX+1, y=Y_MAX+1),
+    scale = Coords(x=3, y=5),
+)
+
+
+@cocotb.test()  # pylint: disable=no-value-for-parameter
+@cocotb.parametrize(params=[SCALE_0X0Y, SCALE_1X1Y, SCALE_2X2Y, SCALE_4X4Y, SCALE_3X5Y])
+async def canv_disp_agu_paint(dut, params):
+    """Test canvas display AGU paint signal."""
     cocotb.start_soon(Clock(dut.clk_pix, PIX_TIME, unit="ns").start())
 
     # reset
@@ -32,24 +93,38 @@ async def address_scale_0x(dut):
     await RisingEdge(dut.clk_pix)
 
     # setup canvas
-    dut.addr_base.value = 12  # base address 0xC
-    dut.addr_shift.value = 3  # 16 colour
-    dut.win_start.value = 0x00000000  # (0,0)
-    dut.win_end.value = 0x00080010  # (height=8,width=16)
-    dut.scale.value = 0x0000000 # 0x in both dimensions (should become 1x)
+    dut.addr_base.value = params.addr_base
+    dut.addr_shift.value = params.addr_shift
+    dut.win_start.value = params.win_start.pack()
+    dut.win_end.value = params.win_end.pack()
+    dut.scale.value = params.scale.pack()
 
-    for dy in range(Y_MIN, Y_MAX+1):
-        for dx in range(X_MIN, X_MAX+1):
-            dut.dy.value = dy
-            dut.dx.value = dx
-            dut.line_start.value = 1 if dx == X_MIN else 0
-            await RisingEdge(dut.clk_pix)
+    for frame in range(2):  # test two frames in a row
+        for dy in range(Y_MIN, Y_MAX+1):
+            for dx in range(X_MIN, X_MAX+1):
+                dut.dy.value = dy
+                dut.dx.value = dx
+                dut.frame_start.value = 1 if dy == Y_MIN and dx == X_MIN else 0
+                dut.line_start.value = 1 if dx == X_MIN else 0
+
+                await ReadOnly()
+                actual_paint = dut.paint.value
+
+                in_window = (params.win_start.y <= dy < params.win_end.y
+                    and params.win_start.x <= dx+CLUT_LAT < params.win_end.x)
+                expected_paint = Logic(1) if in_window else Logic(0)
+
+                if actual_paint.is_resolvable:
+                    assert actual_paint == expected_paint, \
+                        f"paint: '{actual_paint}' is not expected '{expected_paint}' at ({dx}, {dy}) in frame={frame}!"
+
+                await RisingEdge(dut.clk_pix)
 
 
 @cocotb.test()  # pylint: disable=no-value-for-parameter
-async def address_scale_1x(dut):
-    """Test address calculation."""
-
+@cocotb.parametrize(params=[SCALE_0X0Y, SCALE_1X1Y, SCALE_2X2Y, SCALE_4X4Y, SCALE_3X5Y])
+async def canv_disp_agu_addr(dut, params):
+    """Test canvas display AGU pixel address."""
     cocotb.start_soon(Clock(dut.clk_pix, PIX_TIME, unit="ns").start())
 
     # reset
@@ -61,44 +136,45 @@ async def address_scale_1x(dut):
     await RisingEdge(dut.clk_pix)
 
     # setup canvas
-    dut.addr_base.value = 12  # base address 0xC
-    dut.addr_shift.value = 3  # 16 colour
-    dut.win_start.value = 0x00000000  # (0,0)
-    dut.win_end.value = 0x00080010  # (height=8,width=16)
-    dut.scale.value = 0x00010001 # 1x in both dimensions
+    dut.addr_base.value = params.addr_base
+    dut.addr_shift.value = params.addr_shift
+    dut.win_start.value = params.win_start.pack()
+    dut.win_end.value = params.win_end.pack()
+    dut.scale.value = params.scale.pack()
 
-    for dy in range(Y_MIN, Y_MAX+1):
-        for dx in range(X_MIN, X_MAX+1):
-            dut.dy.value = dy
-            dut.dx.value = dx
-            dut.line_start.value = 1 if dx == X_MIN else 0
-            await RisingEdge(dut.clk_pix)
+    for frame in range(2):  # test two frames
+        for dy in range(Y_MIN, Y_MAX+1):
+            for dx in range(X_MIN, X_MAX+1):
+                dut.dy.value = dy
+                dut.dx.value = dx
+                dut.frame_start.value = 1 if dy == Y_MIN and dx == X_MIN else 0
+                dut.line_start.value = 1 if dx == X_MIN else 0
 
+                await ReadOnly()
+                actual_addr_pix = dut.addr_pix.value
+                actual_addr = dut.addr.value
+                actual_pix_id = dut.pix_id.value
 
-@cocotb.test()  # pylint: disable=no-value-for-parameter
-async def address_scale_2x(dut):
-    """Test address calculation."""
+                scale_x = params.scale.x if params.scale.x > 0 else 1
+                scale_y = params.scale.y if params.scale.y > 0 else 1
 
-    cocotb.start_soon(Clock(dut.clk_pix, PIX_TIME, unit="ns").start())
+                ADDR_LAT = CLUT_LAT + VRAM_LAT
+                vram_read = (params.win_start.y <= dy < params.win_end.y
+                    and params.win_start.x <= dx+ADDR_LAT < params.win_end.x)
 
-    # reset
-    dut.rst_pix.value = 0
-    await RisingEdge(dut.clk_pix)
-    dut.rst_pix.value = 1
-    await RisingEdge(dut.clk_pix)
-    dut.rst_pix.value = 0
-    await RisingEdge(dut.clk_pix)
+                line_s = (params.win_end.x - params.win_start.x) // scale_x
+                expected_addr_pix = ((dy - params.win_start.y) // scale_y) * line_s \
+                    + ((dx + ADDR_LAT - params.win_start.x) // scale_x)
 
-    # setup canvas
-    dut.addr_base.value = 12  # base address 0xC
-    dut.addr_shift.value = 3  # 16 colour
-    dut.win_start.value = 0x00000000  # (0,0)
-    dut.win_end.value = 0x00080010  # (height=8,width=16)
-    dut.scale.value = 0x00020002 # 2x in both dimensions
+                expected_addr = params.addr_base + (expected_addr_pix >> params.addr_shift)
 
-    for dy in range(Y_MIN, Y_MAX+1):
-        for dx in range(X_MIN, X_MAX+1):
-            dut.dy.value = dy
-            dut.dx.value = dx
-            dut.line_start.value = 1 if dx == X_MIN else 0
-            await RisingEdge(dut.clk_pix)
+                pix_id_mask = (1 << params.addr_shift) - 1
+                expected_pix_id = expected_addr_pix & pix_id_mask
+
+                if vram_read and actual_addr.is_resolvable and actual_pix_id.is_resolvable:
+                    assert int(actual_addr) == expected_addr, \
+                        f"addr: '{int(actual_addr)}' is not expected '{expected_addr}' at ({dx}, {dy}) in frame={frame}!"
+                    assert int(actual_pix_id) == expected_pix_id, \
+                        f"pix_id: '{int(actual_pix_id)}' is not expected '{expected_pix_id}' at ({dx}, {dy}) in frame={frame}!"
+
+                await RisingEdge(dut.clk_pix)

--- a/hardware/tests/helpers.py
+++ b/hardware/tests/helpers.py
@@ -4,12 +4,24 @@
 
 """Test helpers for Isle cocotb hardware tests."""
 
+from dataclasses import dataclass
+
 import cocotb
 from cocotb.triggers import RisingEdge
 
+@dataclass(frozen=True)
+class Coords:
+    """Isle packed coordinates."""
+    x: int
+    y: int
+
+    def pack(self, width: int = 16) -> int:
+        """Pack coords {y, x} matching Isle hardware."""
+        return (self.y << width) | self.x
+
 
 def assert_coord(dut, x, y):
-    """Assert coordinate is correct"""
+    """Assert coordinate is correct."""
     coord_matches = (
         dut.disp_x.value == x and
         dut.disp_y.value == y
@@ -23,7 +35,7 @@ def assert_coord(dut, x, y):
 
 
 def assert_pixel(dut, r, g, b, verbose=True):
-    """Assert pixel colour is correct"""
+    """Assert pixel colour is correct."""
     if verbose:
         log_pixel(dut)
 


### PR DESCRIPTION
* Register hwreg-based signals to improve timing with high frequency pixel clocks
  - preparation for hwreg written in system clock domain and read in pixel clock domain
  - meets timing in pixel clock domain at ~75 MHz on ECP5 and 150 MHz on XC7
* canv_disp_agu (canvas display address generation)
  - improve cocotb testing (tests cover all output signals with assertions)
  - reset x-counter at line start to handle x-scales that aren't divisors of canvas window
  - paint signal corrected for *clut* latency
  - express canv_disp_agu latencies more clearly
  - improve canv_disp_agu doc/comments
* Explain 1080p FPGA timing situation on Nexys Video
* Write Vivado timing summary to separate file
* Exclude Surfer state files and Vivado timing reports from git
