### PR TITLE
Canvas Display AGU Pipeline Fix

### DIFF
--- a/hardware/docs/canv_disp_agu.md
+++ b/hardware/docs/canv_disp_agu.md
@@ -97,6 +97,8 @@ scale:  0x00020002
 
 [Text mode](textmode.md) windows work in the same way.
 
+The registered signals `scale_x_minus` and `scale_y_minus` are the scaling factors with 1 subtracted to improve the timing slack of the scale counters. For a scale factor of 1x, these _minus signals have a value of 0.
+
 ## Display Pipeline
 
 The bitmap display pipeline has three stages:

--- a/hardware/gfx/canv_disp_agu.v
+++ b/hardware/gfx/canv_disp_agu.v
@@ -100,7 +100,7 @@ module canv_disp_agu #(
     end
 
     // stage 2 - calculate memory address and pixel index
-    wire [PIX_IDW-1:0] pix_id_mask = (1 << addr_shift) - 1;  // pixel index mask
+    wire [PIX_IDW-1:0] pix_id_mask = (1 << addr_shift_p1) - 1;  // pixel index mask
     always @(posedge clk_pix) begin
         /* verilator lint_off WIDTHEXPAND */ /* verilator lint_off WIDTHTRUNC */
         addr <= addr_base_p1 + (addr_pix >> addr_shift_p1);


### PR DESCRIPTION
Canvas display AGU has a pipelined address shift signal (`addr_shift_p1`), but wasn't using it in one of the step two calculations. Also adds an explanation of the `scale_n_minus` signals.